### PR TITLE
Fix documentation on retry-all vs upload-retry

### DIFF
--- a/docs/uppy-core.mdx
+++ b/docs/uppy-core.mdx
@@ -1116,6 +1116,8 @@ uppy.on('upload-error', (file, error, response) => {
 #### `upload-retry`
 
 Fired when an upload has been retried (after an error, for example).
+  
+> ⚠️ Note that this method is event is not triggered when the user retries all uploads, it will trigger the `retry-all` event intstead.
 
 **Parameters**
 
@@ -1126,6 +1128,22 @@ Fired when an upload has been retried (after an error, for example).
 ```js
 uppy.on('upload-retry', (fileID) => {
   console.log('upload retried:', fileID)
+})
+```
+  
+### `retry-all`
+
+Fired when all failed uploads are retried
+
+**Parameters**
+
+* `fileIDs` - Arrays of IDs of the files being retried.
+
+**Example**
+
+```js
+uppy.on('upload-retry', (fileIDs) => {
+  console.log('upload retried:', fileIDs)
 })
 ```
 

--- a/docs/uppy-core.mdx
+++ b/docs/uppy-core.mdx
@@ -1117,7 +1117,9 @@ uppy.on('upload-error', (file, error, response) => {
 
 Fired when an upload has been retried (after an error, for example).
   
-> ⚠️ Note that this method is event is not triggered when the user retries all uploads, it will trigger the `retry-all` event intstead.
+:::note
+This event is not triggered when the user retries all uploads, it will trigger the `retry-all` event instead.
+:::
 
 **Parameters**
 
@@ -1131,7 +1133,7 @@ uppy.on('upload-retry', (fileID) => {
 })
 ```
   
-### `retry-all`
+#### `retry-all`
 
 Fired when all failed uploads are retried
 


### PR DESCRIPTION
Hi,

This is related to https://github.com/transloadit/uppy/pull/3898

When a user do a retry-all no upload-retry event is triggered. (I had to debug this)
The retry-all event is not documented and I think behavior is unexpected (not triggering upload-retry at all)

This at least document current the behavior.

Thanks.

Luc