### PR TITLE
Fix casing of types in docs

### DIFF
--- a/docs/sources/companion-plugins/box.mdx
+++ b/docs/sources/companion-plugins/box.mdx
@@ -125,19 +125,19 @@ companion.app({
 
 #### `id`
 
-A unique identifier for this plugin (`String`, default: `'Box'`).
+A unique identifier for this plugin (`string`, default: `'Box'`).
 
 #### `title`
 
-Title / name shown in the UI, such as Dashboard tabs (`String`, default: `'Box'`).
+Title / name shown in the UI, such as Dashboard tabs (`string`, default: `'Box'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`String` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
 
 #### `companionUrl`
 
-URL to a [Companion](/docs/companion) instance (`String`, default: `null`).
+URL to a [Companion](/docs/companion) instance (`string`, default: `null`).
 
 #### `companionHeaders`
 
@@ -145,14 +145,14 @@ Custom headers that should be sent along to [Companion](/docs/companion) on ever
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`String` or `Regex` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `Regex` or `Array`, default: `companionUrl`).
 
-This value can be a `String`, a `Regex` pattern, or an `Array` of both.
+This value can be a `string`, a `Regex` pattern, or an `Array` of both.
 This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`
 
-This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`String`, default: `'same-origin'`).
+This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`string`, default: `'same-origin'`).
 
 This tells the plugin whether to send cookies to [Companion](/docs/companion).
 

--- a/docs/sources/companion-plugins/box.mdx
+++ b/docs/sources/companion-plugins/box.mdx
@@ -145,9 +145,9 @@ Custom headers that should be sent along to [Companion](/docs/companion) on ever
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `Regex` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `RegExp` or `Array`, default: `companionUrl`).
 
-This value can be a `string`, a `Regex` pattern, or an `Array` of both.
+This value can be a `string`, a `RegExp` pattern, or an `Array` of both.
 This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`

--- a/docs/sources/companion-plugins/dropbox.mdx
+++ b/docs/sources/companion-plugins/dropbox.mdx
@@ -145,9 +145,9 @@ Custom headers that should be sent along to [Companion](/docs/companion) on ever
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `Regex` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `RegExp` or `Array`, default: `companionUrl`).
 
-This value can be a `string`, a `Regex` pattern, or an `Array` of both.
+This value can be a `string`, a `RegExp` pattern, or an `Array` of both.
 This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`

--- a/docs/sources/companion-plugins/dropbox.mdx
+++ b/docs/sources/companion-plugins/dropbox.mdx
@@ -125,19 +125,19 @@ companion.app({
 
 #### `id`
 
-A unique identifier for this plugin (`String`, default: `'Dropbox'`).
+A unique identifier for this plugin (`string`, default: `'Dropbox'`).
 
 #### `title`
 
-Title / name shown in the UI, such as Dashboard tabs (`String`, default: `'Dropbox'`).
+Title / name shown in the UI, such as Dashboard tabs (`string`, default: `'Dropbox'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`String` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
 
 #### `companionUrl`
 
-URL to a [Companion](/docs/companion) instance (`String`, default: `null`).
+URL to a [Companion](/docs/companion) instance (`string`, default: `null`).
 
 #### `companionHeaders`
 
@@ -145,14 +145,14 @@ Custom headers that should be sent along to [Companion](/docs/companion) on ever
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`String` or `Regex` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `Regex` or `Array`, default: `companionUrl`).
 
-This value can be a `String`, a `Regex` pattern, or an `Array` of both.
+This value can be a `string`, a `Regex` pattern, or an `Array` of both.
 This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`
 
-This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`String`, default: `'same-origin'`).
+This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`string`, default: `'same-origin'`).
 
 This tells the plugin whether to send cookies to [Companion](/docs/companion).
 

--- a/docs/sources/companion-plugins/facebook.mdx
+++ b/docs/sources/companion-plugins/facebook.mdx
@@ -118,19 +118,19 @@ companion.app({
 
 #### `id`
 
-A unique identifier for this plugin (`String`, default: `'Facebook'`).
+A unique identifier for this plugin (`string`, default: `'Facebook'`).
 
 #### `title`
 
-Title / name shown in the UI, such as Dashboard tabs (`String`, default: `'Facebook'`).
+Title / name shown in the UI, such as Dashboard tabs (`string`, default: `'Facebook'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`String` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
 
 #### `companionUrl`
 
-URL to a [Companion](/docs/companion) instance (`String`, default: `null`).
+URL to a [Companion](/docs/companion) instance (`string`, default: `null`).
 
 #### `companionHeaders`
 
@@ -138,14 +138,14 @@ Custom headers that should be sent along to [Companion](/docs/companion) on ever
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`String` or `Regex` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `Regex` or `Array`, default: `companionUrl`).
 
-This value can be a `String`, a `Regex` pattern, or an `Array` of both.
+This value can be a `string`, a `Regex` pattern, or an `Array` of both.
 This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`
 
-This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`String`, default: `'same-origin'`).
+This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`string`, default: `'same-origin'`).
 
 This tells the plugin whether to send cookies to [Companion](/docs/companion).
 

--- a/docs/sources/companion-plugins/facebook.mdx
+++ b/docs/sources/companion-plugins/facebook.mdx
@@ -138,9 +138,9 @@ Custom headers that should be sent along to [Companion](/docs/companion) on ever
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `Regex` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `RegExp` or `Array`, default: `companionUrl`).
 
-This value can be a `string`, a `Regex` pattern, or an `Array` of both.
+This value can be a `string`, a `RegExp` pattern, or an `Array` of both.
 This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`

--- a/docs/sources/companion-plugins/google-drive.mdx
+++ b/docs/sources/companion-plugins/google-drive.mdx
@@ -118,19 +118,19 @@ companion.app({
 
 #### `id`
 
-A unique identifier for this plugin (`String`, default: `'GoogleDrive'`).
+A unique identifier for this plugin (`string`, default: `'GoogleDrive'`).
 
 #### `title`
 
-Title / name shown in the UI, such as Dashboard tabs (`String`, default: `'GoogleDrive'`).
+Title / name shown in the UI, such as Dashboard tabs (`string`, default: `'GoogleDrive'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`String` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
 
 #### `companionUrl`
 
-URL to a [Companion](/docs/companion) instance (`String`, default: `null`).
+URL to a [Companion](/docs/companion) instance (`string`, default: `null`).
 
 #### `companionHeaders`
 
@@ -138,14 +138,14 @@ Custom headers that should be sent along to [Companion](/docs/companion) on ever
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`String` or `Regex` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `Regex` or `Array`, default: `companionUrl`).
 
-This value can be a `String`, a `Regex` pattern, or an `Array` of both.
+This value can be a `string`, a `Regex` pattern, or an `Array` of both.
 This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`
 
-This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`String`, default: `'same-origin'`).
+This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`string`, default: `'same-origin'`).
 
 This tells the plugin whether to send cookies to [Companion](/docs/companion).
 

--- a/docs/sources/companion-plugins/google-drive.mdx
+++ b/docs/sources/companion-plugins/google-drive.mdx
@@ -138,9 +138,9 @@ Custom headers that should be sent along to [Companion](/docs/companion) on ever
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `Regex` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `RegExp` or `Array`, default: `companionUrl`).
 
-This value can be a `string`, a `Regex` pattern, or an `Array` of both.
+This value can be a `string`, a `RegExp` pattern, or an `Array` of both.
 This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`

--- a/docs/sources/companion-plugins/instagram.mdx
+++ b/docs/sources/companion-plugins/instagram.mdx
@@ -137,9 +137,9 @@ Custom headers that should be sent along to [Companion](/docs/companion) on ever
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `Regex` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `RegExp` or `Array`, default: `companionUrl`).
 
-This value can be a `string`, a `Regex` pattern, or an `Array` of both.
+This value can be a `string`, a `RegExp` pattern, or an `Array` of both.
 This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`

--- a/docs/sources/companion-plugins/instagram.mdx
+++ b/docs/sources/companion-plugins/instagram.mdx
@@ -117,19 +117,19 @@ companion.app({
 
 #### `id`
 
-A unique identifier for this plugin (`String`, default: `'Instagram'`).
+A unique identifier for this plugin (`string`, default: `'Instagram'`).
 
 #### `title`
 
-Title / name shown in the UI, such as Dashboard tabs (`String`, default: `'Instagram'`).
+Title / name shown in the UI, such as Dashboard tabs (`string`, default: `'Instagram'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`String` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
 
 #### `companionUrl`
 
-URL to a [Companion](/docs/companion) instance (`String`, default: `null`).
+URL to a [Companion](/docs/companion) instance (`string`, default: `null`).
 
 #### `companionHeaders`
 
@@ -137,14 +137,14 @@ Custom headers that should be sent along to [Companion](/docs/companion) on ever
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`String` or `Regex` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `Regex` or `Array`, default: `companionUrl`).
 
-This value can be a `String`, a `Regex` pattern, or an `Array` of both.
+This value can be a `string`, a `Regex` pattern, or an `Array` of both.
 This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`
 
-This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`String`, default: `'same-origin'`).
+This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`string`, default: `'same-origin'`).
 
 This tells the plugin whether to send cookies to [Companion](/docs/companion).
 

--- a/docs/sources/companion-plugins/onedrive.mdx
+++ b/docs/sources/companion-plugins/onedrive.mdx
@@ -137,9 +137,9 @@ Custom headers that should be sent along to [Companion](/docs/companion) on ever
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `Regex` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `RegExp` or `Array`, default: `companionUrl`).
 
-This value can be a `string`, a `Regex` pattern, or an `Array` of both.
+This value can be a `string`, a `RegExp` pattern, or an `Array` of both.
 This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`

--- a/docs/sources/companion-plugins/onedrive.mdx
+++ b/docs/sources/companion-plugins/onedrive.mdx
@@ -117,19 +117,19 @@ companion.app({
 
 #### `id`
 
-A unique identifier for this plugin (`String`, default: `'OneDrive'`).
+A unique identifier for this plugin (`string`, default: `'OneDrive'`).
 
 #### `title`
 
-Title / name shown in the UI, such as Dashboard tabs (`String`, default: `'OneDrive'`).
+Title / name shown in the UI, such as Dashboard tabs (`string`, default: `'OneDrive'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`String` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
 
 #### `companionUrl`
 
-URL to a [Companion](/docs/companion) instance (`String`, default: `null`).
+URL to a [Companion](/docs/companion) instance (`string`, default: `null`).
 
 #### `companionHeaders`
 
@@ -137,14 +137,14 @@ Custom headers that should be sent along to [Companion](/docs/companion) on ever
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`String` or `Regex` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `Regex` or `Array`, default: `companionUrl`).
 
-This value can be a `String`, a `Regex` pattern, or an `Array` of both.
+This value can be a `string`, a `Regex` pattern, or an `Array` of both.
 This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`
 
-This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`String`, default: `'same-origin'`).
+This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`string`, default: `'same-origin'`).
 
 This tells the plugin whether to send cookies to [Companion](/docs/companion).
 

--- a/docs/sources/companion-plugins/unsplash.mdx
+++ b/docs/sources/companion-plugins/unsplash.mdx
@@ -130,9 +130,9 @@ Custom headers that should be sent along to [Companion](/docs/companion) on ever
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `Regex` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `RegExp` or `Array`, default: `companionUrl`).
 
-This value can be a `string`, a `Regex` pattern, or an `Array` of both.
+This value can be a `string`, a `RegExp` pattern, or an `Array` of both.
 This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`

--- a/docs/sources/companion-plugins/unsplash.mdx
+++ b/docs/sources/companion-plugins/unsplash.mdx
@@ -110,19 +110,19 @@ companion.app({
 
 #### `id`
 
-A unique identifier for this plugin (`String`, default: `'Unsplash'`).
+A unique identifier for this plugin (`string`, default: `'Unsplash'`).
 
 #### `title`
 
-Title / name shown in the UI, such as Dashboard tabs (`String`, default: `'Unsplash'`).
+Title / name shown in the UI, such as Dashboard tabs (`string`, default: `'Unsplash'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`String` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
 
 #### `companionUrl`
 
-URL to a [Companion](/docs/companion) instance (`String`, default: `null`).
+URL to a [Companion](/docs/companion) instance (`string`, default: `null`).
 
 #### `companionHeaders`
 
@@ -130,14 +130,14 @@ Custom headers that should be sent along to [Companion](/docs/companion) on ever
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`String` or `Regex` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `Regex` or `Array`, default: `companionUrl`).
 
-This value can be a `String`, a `Regex` pattern, or an `Array` of both.
+This value can be a `string`, a `Regex` pattern, or an `Array` of both.
 This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`
 
-This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`String`, default: `'same-origin'`).
+This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`string`, default: `'same-origin'`).
 
 This tells the plugin whether to send cookies to [Companion](/docs/companion).
 

--- a/docs/sources/companion-plugins/url.mdx
+++ b/docs/sources/companion-plugins/url.mdx
@@ -113,9 +113,9 @@ Custom headers that should be sent along to [Companion](/docs/companion) on ever
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `Regex` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `RegExp` or `Array`, default: `companionUrl`).
 
-This value can be a `string`, a `Regex` pattern, or an `Array` of both.
+This value can be a `string`, a `RegExp` pattern, or an `Array` of both.
 This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`

--- a/docs/sources/companion-plugins/url.mdx
+++ b/docs/sources/companion-plugins/url.mdx
@@ -93,19 +93,19 @@ Companion supports this plugin out-of-the-box so integration is required on this
 
 #### `id`
 
-A unique identifier for this plugin (`String`, default: `'Url'`).
+A unique identifier for this plugin (`string`, default: `'Url'`).
 
 #### `title`
 
-Title / name shown in the UI, such as Dashboard tabs (`String`, default: `'Url'`).
+Title / name shown in the UI, such as Dashboard tabs (`string`, default: `'Url'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`String` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
 
 #### `companionUrl`
 
-URL to a [Companion](/docs/companion) instance (`String`, default: `null`).
+URL to a [Companion](/docs/companion) instance (`string`, default: `null`).
 
 #### `companionHeaders`
 
@@ -113,14 +113,14 @@ Custom headers that should be sent along to [Companion](/docs/companion) on ever
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`String` or `Regex` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `Regex` or `Array`, default: `companionUrl`).
 
-This value can be a `String`, a `Regex` pattern, or an `Array` of both.
+This value can be a `string`, a `Regex` pattern, or an `Array` of both.
 This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`
 
-This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`String`, default: `'same-origin'`).
+This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`string`, default: `'same-origin'`).
 
 This tells the plugin whether to send cookies to [Companion](/docs/companion).
 

--- a/docs/sources/companion-plugins/zoom.mdx
+++ b/docs/sources/companion-plugins/zoom.mdx
@@ -127,9 +127,9 @@ Custom headers that should be sent along to [Companion](/docs/companion) on ever
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `Regex` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `RegExp` or `Array`, default: `companionUrl`).
 
-This value can be a `string`, a `Regex` pattern, or an `Array` of both.
+This value can be a `string`, a `RegExp` pattern, or an `Array` of both.
 This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`

--- a/docs/sources/companion-plugins/zoom.mdx
+++ b/docs/sources/companion-plugins/zoom.mdx
@@ -107,19 +107,19 @@ companion.app({
 
 #### `id`
 
-A unique identifier for this plugin (`String`, default: `'Zoom'`).
+A unique identifier for this plugin (`string`, default: `'Zoom'`).
 
 #### `title`
 
-Title / name shown in the UI, such as Dashboard tabs (`String`, default: `'Zoom'`).
+Title / name shown in the UI, such as Dashboard tabs (`string`, default: `'Zoom'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`String` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
 
 #### `companionUrl`
 
-URL to a [Companion](/docs/companion) instance (`String`, default: `null`).
+URL to a [Companion](/docs/companion) instance (`string`, default: `null`).
 
 #### `companionHeaders`
 
@@ -127,14 +127,14 @@ Custom headers that should be sent along to [Companion](/docs/companion) on ever
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`String` or `Regex` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `Regex` or `Array`, default: `companionUrl`).
 
-This value can be a `String`, a `Regex` pattern, or an `Array` of both.
+This value can be a `string`, a `Regex` pattern, or an `Array` of both.
 This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`
 
-This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`String`, default: `'same-origin'`).
+This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`string`, default: `'same-origin'`).
 
 This tells the plugin whether to send cookies to [Companion](/docs/companion).
 

--- a/docs/sources/screen-capture.mdx
+++ b/docs/sources/screen-capture.mdx
@@ -97,15 +97,15 @@ new Uppy
 
 #### `id`
 
-A unique identifier for this plugin (`String`, default: `'ScreenCapture'`).
+A unique identifier for this plugin (`string`, default: `'ScreenCapture'`).
 
 #### `title`
 
-Configures the title / name shown in the UI, for instance, on Dashboard tabs (`String`, default: `'Screen Capture'`).
+Configures the title / name shown in the UI, for instance, on Dashboard tabs (`string`, default: `'Screen Capture'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`String` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
 
 #### `displayMediaConstraints`
 
@@ -121,7 +121,7 @@ See the [`MediaTrackConstraints`](https://developer.mozilla.org/en-US/docs/Web/A
 
 #### `preferredVideoMimeType`
 
-Set the preferred mime type for video recordings, for example `'video/webm'` (`String`, default: `null`).
+Set the preferred mime type for video recordings, for example `'video/webm'` (`string`, default: `null`).
 
 If the browser supports the given mime type, the video will be recorded in this format.
 If the browser does not support it, it will use the browser default.

--- a/docs/sources/webcam.mdx
+++ b/docs/sources/webcam.mdx
@@ -100,15 +100,15 @@ new Uppy
 
 #### `id`
 
-A unique identifier for this plugin (`String`, default: `'Webcam'`).
+A unique identifier for this plugin (`string`, default: `'Webcam'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`String` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
 
 #### `countdown`
 
-When taking a picture: the amount of seconds to wait before actually taking a snapshot (`Boolean`, default: `false`).
+When taking a picture: the amount of seconds to wait before actually taking a snapshot (`boolean`, default: `false`).
 
 If set to `false` or 0, the snapshot is taken right away.
 This also shows a `Smile!` message through the [Informer](/docs/informer) before the picture is taken.
@@ -133,7 +133,7 @@ By default, all modes are allowed, and the Webcam plugin will show controls for 
 
 #### `mirror`
 
-Configures whether to mirror preview image from the camera (`Boolean`, default: `true`).
+Configures whether to mirror preview image from the camera (`boolean`, default: `true`).
 
 This option is useful when taking a selfie with a front camera: when you wave your right hand,
 you will see your hand on the right on the preview screen, like in the mirror.
@@ -166,17 +166,17 @@ For a full list of available properties, check out MDN documentation for [`Media
 
 #### `showVideoSourceDropdown`
 
-Configures whether to show a dropdown which enables to choose the video device to use (`Boolean`, default: `false`).
+Configures whether to show a dropdown which enables to choose the video device to use (`boolean`, default: `false`).
 
 This option will have priority over `facingMode` if enabled.
 
 #### `showRecordingLength`
 
-Configures whether to show the length of the recording while the recording is in progress (`Boolean`, default: `false`).
+Configures whether to show the length of the recording while the recording is in progress (`boolean`, default: `false`).
  
 #### `preferredVideoMimeType`
 
-Set the preferred mime type for video recordings, for example `'video/webm'` (`String`, default: `null`).
+Set the preferred mime type for video recordings, for example `'video/webm'` (`string`, default: `null`).
 
 If the browser supports the given mime type, the video will be recorded in this format.
 If the browser does not support it, it will use the browser default.
@@ -184,7 +184,7 @@ If no preferred video mime type is given, the Webcam plugin will prefer types li
 
 #### `preferredImageMimeType`
 
-Set the preferred mime type for images, for example `'image/png'` (`String`, default: `image/jpeg`). 
+Set the preferred mime type for images, for example `'image/png'` (`string`, default: `image/jpeg`). 
 
 If the browser supports rendering the given mime type, the image will be stored in this format.
 Else `image/jpeg` is used by default.

--- a/docs/uppy-core.mdx
+++ b/docs/uppy-core.mdx
@@ -207,7 +207,7 @@ If you are integrating with an existing HTML form, this option gives the closest
 
 #### `debug`
 
-Whether to send debugging and warning logs (`Boolean`, default: `false`).
+Whether to send debugging and warning logs (`boolean`, default: `false`).
 
 Setting this to `true` sets the [`logger`](#logger) to [`debugLogger`](#debuglogger).
 
@@ -242,11 +242,11 @@ Conditions for restricting an upload (`Object`, default: `{}`).
 
 | Property             | Value           | Description                                                                                                                      |
 | -------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `maxFileSize`        | `Number`        | maximum file size in bytes for each individual file                                                                              |
-| `minFileSize`        | `Number`        | minimum file size in bytes for each individual file                                                                              |
-| `maxTotalFileSize`   | `Number`        | maximum file size in bytes for all the files that can be selected for upload                                                     |
-| `maxNumberOfFiles`   | `Number`        | total number of files that can be selected                                                                                       |
-| `minNumberOfFiles`   | `Number`        | minimum number of files that must be selected before the upload                                                                  |
+| `maxFileSize`        | `number`        | maximum file size in bytes for each individual file                                                                              |
+| `minFileSize`        | `number`        | minimum file size in bytes for each individual file                                                                              |
+| `maxTotalFileSize`   | `number`        | maximum file size in bytes for all the files that can be selected for upload                                                     |
+| `maxNumberOfFiles`   | `number`        | total number of files that can be selected                                                                                       |
+| `minNumberOfFiles`   | `number`        | minimum number of files that must be selected before the upload                                                                  |
 | `allowedFileTypes`   | `Array`         | wildcards `image/*`, or exact mime types `image/jpeg`, or file extensions `.jpg`: `['image/*', '.jpg', '.jpeg', '.png', '.gif']` |
 | `requiredMetaFields` | `Array<string>` | make keys from the `meta` object in every file required before uploading                                                         |
 
@@ -508,7 +508,7 @@ This option can be used to plug Uppy state into an external state management lib
 
 #### `infoTimeout`
 
-How long an [Informer](/docs/user-interfaces/elements/informer) notification will be visible (`Number`, default: `5000`).
+How long an [Informer](/docs/user-interfaces/elements/informer) notification will be visible (`number`, default: `5000`).
 
 ### Methods
 
@@ -772,8 +772,8 @@ Useful, for example, after your users log out of their account in your app
 
 | Argument  | Type      | Description                 |
 | --------- | --------- | --------------------------- |
-| `message` | `String`  | message to log              |
-| `type`    | `String?` | `debug`, `warn`, or `error` |
+| `message` | `string`  | message to log              |
+| `type`    | `string?` | `debug`, `warn`, or `error` |
 
 See [`logger`](#logger) docs for details.
 
@@ -788,9 +788,9 @@ It’s using the [Informer](/docs/interfaces/elements/informer/) plugin, include
 
 | Argument   | Type               | Description                                                                       |
 | ---------- | ------------------ | --------------------------------------------------------------------------------- |
-| `message`  | `String`, `Object` | `'info message'` or `{ message: 'Oh no!', details: 'File couldn’t be uploaded' }` |
-| `type`     | `String?`          | `'info'`, `'warning'`, `'success'` or `'error'`                                   |
-| `duration` | `Number?`          | in milliseconds                                                                   |
+| `message`  | `string`, `Object` | `'info message'` or `{ message: 'Oh no!', details: 'File couldn’t be uploaded' }` |
+| `type`     | `string?`          | `'info'`, `'warning'`, `'success'` or `'error'`                                   |
+| `duration` | `number?`          | in milliseconds                                                                   |
 
 `info-visible` and `info-hidden` events are emitted when this info message should be visible or hidden.
 

--- a/docs/user-interfaces/dashboard.mdx
+++ b/docs/user-interfaces/dashboard.mdx
@@ -135,41 +135,41 @@ new Uppy.use(Dashboard, {
 
 #### `id`
 
-A unique identifier for this plugin (`String`, default: `'Dashboard'`).
+A unique identifier for this plugin (`string`, default: `'Dashboard'`).
 
 Plugins that are added by the Dashboard get unique IDs based on this ID, like `'Dashboard:StatusBar'` and `'Dashboard:Informer'`.
 
 #### `target`
 
-Where to render the Dashboard (`String` or `Element`, default: `'body'`). 
+Where to render the Dashboard (`string` or `Element`, default: `'body'`). 
 
 You can pass an element, class, or id as a string. 
 Dashboard is rendered into `body`, because it’s hidden by default and only opened as a modal when `trigger` is clicked.
 
 #### `inline`
 
-Render the Dashboard as a modal or inline (`Boolean`, default: `false`).
+Render the Dashboard as a modal or inline (`boolean`, default: `false`).
 
 When `false`, Dashboard is opened by clicking on [`trigger`](#trigger).
 If `inline: true`, Dashboard will be rendered into [`target`](#target) and fit right in.
 
 #### `trigger`
 
-A CSS selector for a button that will trigger opening the Dashboard modal (`String`, default: `null`).
+A CSS selector for a button that will trigger opening the Dashboard modal (`string`, default: `null`).
 
 Several buttons or links can be used, as long as they are selected using the same selector (`.select-file-button`, for example).
 
 #### `width`
 
-Width of the Dashboard in pixels (`Number`, default: `750`). Used when `inline: true`.
+Width of the Dashboard in pixels (`number`, default: `750`). Used when `inline: true`.
 
 #### `height`
 
-Height of the Dashboard in pixels (`Number`, default: `550`). Used when `inline: true`.
+Height of the Dashboard in pixels (`number`, default: `550`). Used when `inline: true`.
 
 #### `waitForThumbnailsBeforeUpload`
 
-Whether to wait for all thumbnails from `@uppy/thumbnail-generator` to be ready before starting the upload (`Boolean`, default `false`).
+Whether to wait for all thumbnails from `@uppy/thumbnail-generator` to be ready before starting the upload (`boolean`, default `false`).
 
 If set to `true`, Thumbnail Generator will envoke Uppy’s internal processing stage, displaying “Generating thumbnails...” message, and wait for `thumbnail:all-generated` event, before proceeding to the uploading stage.
 
@@ -177,13 +177,13 @@ This is useful because Thumbnail Generator also adds EXIF data to images, and if
 
 #### `showLinkToFileUploadResult`
 
-Turn the file icon and thumbnail in the Dashboard into a link to the uploaded file (`Boolean`, default: `false`).
+Turn the file icon and thumbnail in the Dashboard into a link to the uploaded file (`boolean`, default: `false`).
 
 Please make sure to return the `url` key (or the one set via `responseUrlFieldName`) from your server.
 
 #### `showProgressDetails`
 
-Show or hise progress details in the status bar (`Boolean`, default: `false`).
+Show or hise progress details in the status bar (`boolean`, default: `false`).
 
 By default, progress in Status Bar is shown as a percentage. If you would like to also display remaining upload size and time, set this to `true`.
 
@@ -193,32 +193,32 @@ By default, progress in Status Bar is shown as a percentage. If you would like t
 
 #### `hideUploadButton`
 
-Show or hide the upload button (`Boolean`, default: `false`).
+Show or hide the upload button (`boolean`, default: `false`).
 
 Use this if you are providing a custom upload button somewhere, and are using the `uppy.upload()` API.
 
 #### `hideRetryButton`
 
-Hide the retry button in the status bar and on each individual file (`Boolean`, default: `false`).
+Hide the retry button in the status bar and on each individual file (`boolean`, default: `false`).
 
 Use this if you are providing a custom retry button somewhere and if you are using the `uppy.retryAll()` or `uppy.retryUpload(fileID)` API.
 
 #### `hidePauseResumeButton`
 
 Hide the pause/resume button (for resumable uploads, via [tus](http://tus.io), for example) in the status bar and on each individual file
-(`Boolean`, default: `false`).
+(`boolean`, default: `false`).
 
 Use this if you are providing custom cancel or pause/resume buttons somewhere, and using the `uppy.pauseResume(fileID)` or `uppy.removeFile(fileID)` API.
 
 #### `hideCancelButton`
 
-Hide the cancel button in status bar and on each individual file (`Boolean`, default: `false`).
+Hide the cancel button in status bar and on each individual file (`boolean`, default: `false`).
 
 Use this if you are providing a custom retry button somewhere, and using the `uppy.cancelAll()` API.
 
 #### `hideProgressAfterFinish`
 
-Hide the status bar after the upload has finished (`Boolean`, default: `false`).
+Hide the status bar after the upload has finished (`boolean`, default: `false`).
 
 #### `doneButtonHandler()`
 
@@ -238,7 +238,7 @@ Set to `null` to disable the “Done” button.
 
 #### `showSelectedFiles`
 
-Show the list of added files with a preview and file information (`Boolean`, default: `true`).
+Show the list of added files with a preview and file information (`boolean`, default: `true`).
 
 In case you are showing selected files in your own app’s UI and want the Uppy Dashboard to only be a picker, the list can be hidden with this option.
 
@@ -246,7 +246,7 @@ See also [`disableStatusBar`](#disablestatusbar) option, which can hide the prog
 
 #### `showRemoveButtonAfterComplete`
 
-Show the remove button on every file after a successful upload (`Boolean`, default: `false`).
+Show the remove button on every file after a successful upload (`boolean`, default: `false`).
 
 Enabling this option only shows the remove `X` button in the Dashboard UI,
 but to actually send a request you should listen to [`file-removed`](https://uppy.io/docs/uppy/#file-removed) event and add your logic there.
@@ -264,7 +264,7 @@ For an implementation example, please see [#2301](https://github.com/transloadit
 
 #### `note`
 
-A string of text to be placed in the Dashboard UI (`String`, default: `null`). 
+A string of text to be placed in the Dashboard UI (`string`, default: `null`). 
 
 This could for instance be used to explain any [`restrictions`](#restrictions) that are put in place.
 For example: `'Images and video only, 2–3 files, up to 1 MB'`.
@@ -350,11 +350,11 @@ uppy.use(Dashboard, {
 
 #### `closeModalOnClickOutside`
 
-Set to true to automatically close the modal when the user clicks outside of it (`Boolean`, default: `false`).
+Set to true to automatically close the modal when the user clicks outside of it (`boolean`, default: `false`).
 
 #### `closeAfterFinish`
 
-Set to true to automatically close the modal when all current uploads are complete (`Boolean`, default: `false`).
+Set to true to automatically close the modal when all current uploads are complete (`boolean`, default: `false`).
 
 With this option, the modal is only automatically closed when uploads are complete _and successful_.
 If some uploads failed, the modal stays open so the user can retry failed uploads or cancel the current batch and upload an entirely different set of files instead.
@@ -368,7 +368,7 @@ This is recommended. With several upload batches, the auto-closing behavior can 
 
 #### `disablePageScrollWhenModalOpen`
 
-Disable page scroll when the modal is open (`Boolean`, default: `true`).
+Disable page scroll when the modal is open (`boolean`, default: `true`).
 
 Page scrolling is disabled by default when the Dashboard modal is open, so when you scroll a list of files in Uppy,
 the website in the background stays still.
@@ -376,39 +376,39 @@ Set to false to override this behaviour and leave page scrolling intact.
 
 #### `animateOpenClose`
 
-Add animations when the modal dialog is opened or closed, for a more satisfying user experience (`Boolean`, default: `true`).
+Add animations when the modal dialog is opened or closed, for a more satisfying user experience (`boolean`, default: `true`).
 
 #### `fileManagerSelectionType`
 
-Configure the type of selections allowed when browsing your file system via the file manager selection window (`String`, default: `'files'`).
+Configure the type of selections allowed when browsing your file system via the file manager selection window (`string`, default: `'files'`).
 
 May be either `'files'`, `'folders'`, or `'both'`.
 Selecting entire folders for upload may not be supported on all [browsers](https://caniuse.com/#feat=input-file-directory).
 
 #### `proudlyDisplayPoweredByUppy`
 
-Show the Uppy logo with a link (`Boolean`, default: `true`).
+Show the Uppy logo with a link (`boolean`, default: `true`).
 
 Uppy is provided to the world for free by the team behind [Transloadit](https://transloadit.com). 
 In return, we ask that you consider keeping a tiny Uppy logo at the bottom of the Dashboard, so that more people can discover and use Uppy.
 
 #### `disableStatusBar`
 
-Disable the status bar completely (`Boolean`, default: `false`).
+Disable the status bar completely (`boolean`, default: `false`).
 
 Dashboard ships with the `StatusBar` plugin that shows upload progress and pause/resume/cancel buttons.
 If you want, you can disable the StatusBar to provide your own custom solution.
 
 #### `disableInformer: false`
 
-Disable informer (shows notifications in the form of toasts) completely (`Boolean`, default: `false`).
+Disable informer (shows notifications in the form of toasts) completely (`boolean`, default: `false`).
 
 Dashboard ships with the `Informer` plugin that notifies when the browser is offline, or when it’s time to say cheese if `Webcam` is taking a picture.
 If you want, you can disable the Informer and/or provide your own custom solution.
 
 #### `disableThumbnailGenerator`
 
-Disable the thumbnail generator completely (`Boolean`, default: `false`).
+Disable the thumbnail generator completely (`boolean`, default: `false`).
 
 Dashboard ships with the `ThumbnailGenerator` plugin that adds small resized image thumbnails to images, for preview purposes only.
 If you want, you can disable the `ThumbnailGenerator` and/or provide your own custom solution.
@@ -509,7 +509,7 @@ module.exports = {
 
 #### `theme`
 
-Light or dark theme for the Dashboard (`String`, default: `'light'`).
+Light or dark theme for the Dashboard (`string`, default: `'light'`).
 
 Uppy Dashboard supports “Dark Mode”. You can try it live on [the Dashboard example page](https://uppy.io/examples/dashboard/).
 
@@ -521,14 +521,14 @@ It supports the following values:
 
 #### `autoOpenFileEditor`
 
-Automatically open file editor (see [`@uppy/image-editor`](/docs/user-interfaces/elements/image-editor/)) for the first file in a batch (`Boolean`, default: `false`).
+Automatically open file editor (see [`@uppy/image-editor`](/docs/user-interfaces/elements/image-editor/)) for the first file in a batch (`boolean`, default: `false`).
 
 If one file is added, editor opens for that file, if 10 files are added — editor opens for the first file.
 Use case: user adds an image — Uppy opens Image Editor right away — user crops / adjusts the image — upload.
 
 #### `disabled`
 
-Enabling this option makes the Dashboard grayed-out and non-interactive (`Boolean`, default: `false`).
+Enabling this option makes the Dashboard grayed-out and non-interactive (`boolean`, default: `false`).
 
 Users won’t be able to click on buttons or drop files.
 Useful when you need to conditionally enable/disable file uploading or manipulation, based on a condition in your app. Can be set on init or via API:
@@ -544,7 +544,7 @@ userNameInput.addEventListener('change', () => {
 
 #### `disableLocalFiles`
 
-Disable local files (`Boolean`, default: `false`).
+Disable local files (`boolean`, default: `false`).
 
 Enabling this option will disable drag & drop, hide the “browse” and “My Device” button,
 allowing only uploads from plugins, such as Webcam, Screen Capture, Google Drive, Instagram.

--- a/docs/user-interfaces/drag-drop.mdx
+++ b/docs/user-interfaces/drag-drop.mdx
@@ -86,29 +86,29 @@ new Uppy().use(DragDrop, {
 
 #### `id`
 
-A unique identifier for this plugin (`String`, Default: `'DragDrop'`).
+A unique identifier for this plugin (`string`, Default: `'DragDrop'`).
 
 Use this if you need to add several DragDrop instances.
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`String` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
 
 #### `width`
 
-Drag and drop area width (`String`, default: `'100%'`).
+Drag and drop area width (`string`, default: `'100%'`).
 
 Set in inline CSS, so feel free to use percentage, pixels or other values that you like.
 
 #### `height`
 
-Drag and drop area height (`String`, default: `'100%'`).
+Drag and drop area height (`string`, default: `'100%'`).
 
 Set in inline CSS, so feel free to use percentage, pixels or other values that you like.
 
 #### `note`
 
-Optionally, specify a string of text that explains something about the upload for the user (`String`, default: `null`).
+Optionally, specify a string of text that explains something about the upload for the user (`string`, default: `null`).
 
 This is a place to explain any `restrictions` that are put in place. For example: `'Images and video only, 2–3 files, up to 1 MB'`.
 

--- a/docs/user-interfaces/elements/image-editor.mdx
+++ b/docs/user-interfaces/elements/image-editor.mdx
@@ -101,11 +101,11 @@ new Uppy()
 
 #### `id`
 
-A unique identifier for this plugin (`String`, default: `'ImageEditor'`).
+A unique identifier for this plugin (`string`, default: `'ImageEditor'`).
 
 #### `quality`
 
-Quality Of the resulting blob that will be saved in Uppy after editing/cropping (`Number`, default: `0.8`).
+Quality Of the resulting blob that will be saved in Uppy after editing/cropping (`number`, default: `0.8`).
 
 #### `cropperOptions`
 
@@ -116,7 +116,7 @@ with the addition of `croppedCanvasOptions`, which will be passed to [`getCroppe
 
 #### `actions`
 
-Shown action buttons (`Object` or `Boolean`).
+Shown action buttons (`Object` or `boolean`).
 
 If you you’d like to hide all actions, pass `false` to it. By default all the actions are visible.
 Or enable/disable them individually:

--- a/docs/user-interfaces/elements/informer.mdx
+++ b/docs/user-interfaces/elements/informer.mdx
@@ -86,11 +86,11 @@ and will emit [`info-hidden`](/docs/uppy-core#info-hidden) after the timeout.
 
 ### `id`
 
-A unique identifier for this plugin (`String`, default: `'Informer'`). 
+A unique identifier for this plugin (`string`, default: `'Informer'`). 
 
 Use this if you need several `Informer` instances.
 
 ### `target`
 
-DOM element, CSS selector, or plugin to mount the Informer into (`String` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to mount the Informer into (`string` or `Element`, default: `null`).
 

--- a/docs/user-interfaces/elements/progress-bar.mdx
+++ b/docs/user-interfaces/elements/progress-bar.mdx
@@ -82,20 +82,20 @@ uppy.use(ProgressBar, {
 
 #### `id`
 
-A unique identifier for this Status Bar (`String`, default: `'ProgressBar'`). 
+A unique identifier for this Status Bar (`string`, default: `'ProgressBar'`). 
 
 Use this if you need to add several ProgressBar instances.
 
 #### `target`
 
-DOM element, CSS selector, or plugin to mount the Status Bar into (`Element`, `String`, default: `null`).
+DOM element, CSS selector, or plugin to mount the Status Bar into (`Element`, `string`, default: `null`).
 
 #### `fixed`
 
-Show the progress bar at the top of the page with `position: fixed` (`Boolean`, default: `false`).
+Show the progress bar at the top of the page with `position: fixed` (`boolean`, default: `false`).
 
 When set to false, show the progress bar inline wherever it’s mounted.
 
 #### `hideAfterFinish`
 
-Hides the progress bar after the upload has finished (`Boolean`, default: `true`).
+Hides the progress bar after the upload has finished (`boolean`, default: `true`).

--- a/docs/user-interfaces/elements/status-bar.mdx
+++ b/docs/user-interfaces/elements/status-bar.mdx
@@ -93,21 +93,21 @@ uppy.use(StatusBar, {
 
 #### `id`
 
-A unique identifier for this Status Bar (`String`, default: `'StatusBar'`). 
+A unique identifier for this Status Bar (`string`, default: `'StatusBar'`). 
 
 Use this if you need to add several StatusBar instances.
 
 #### `target`
 
-DOM element, CSS selector, or plugin to mount the Status Bar into (`Element`, `String`, `UIPlugin`, default: `'body'`).
+DOM element, CSS selector, or plugin to mount the Status Bar into (`Element`, `string`, `UIPlugin`, default: `'body'`).
 
 #### `hideAfterFinish`
 
-Hide the Status Bar after the upload is complete (`Boolean`, default: `true`).
+Hide the Status Bar after the upload is complete (`boolean`, default: `true`).
 
 #### `showProgressDetails`
 
-Display remaining upload size and estimated time (`Boolean`, default: `false`)
+Display remaining upload size and estimated time (`boolean`, default: `false`)
 
 :::note
 `false`: Uploading: 45%
@@ -117,25 +117,25 @@ Display remaining upload size and estimated time (`Boolean`, default: `false`)
 
 #### `hideUploadButton`
 
-Hide the upload button (`Boolean`, default: `false`).
+Hide the upload button (`boolean`, default: `false`).
 
 Use this if you are providing a custom upload button somewhere, and using the `uppy.upload()` API.
 
 #### `hideRetryButton`
 
-Hide the retry button (`Boolean`, default: `false`).
+Hide the retry button (`boolean`, default: `false`).
 
 Use this if you are providing a custom retry button somewhere, and using the `uppy.retryAll()` or `uppy.retryUpload(fileID)` API.
 
 #### `hidePauseResumeButton`
 
-Hide pause/resume buttons (for resumable uploads, via [tus](http://tus.io), for example) (`Boolean`, default: `false`).
+Hide pause/resume buttons (for resumable uploads, via [tus](http://tus.io), for example) (`boolean`, default: `false`).
 
 Use this if you are providing custom cancel or pause/resume buttons somewhere, and using the `uppy.pauseResume(fileID)` or `uppy.removeFile(fileID)` API.
 
 #### `hideCancelButton`
 
-Hide the cancel button (`Boolean`, default: `false`).
+Hide the cancel button (`boolean`, default: `false`).
 
 Use this if you are providing a custom retry button somewhere, and using the `uppy.cancelAll()` API.
 

--- a/docs/user-interfaces/elements/thumbnail-generator.mdx
+++ b/docs/user-interfaces/elements/thumbnail-generator.mdx
@@ -81,7 +81,7 @@ uppy.on("thumbnail:generated", (file, preview) => doSomething(file, preview));
 
 #### `id`
 
-A unique identifier for this plugin (`String`, default: `'ThumbnailGenerator'`).
+A unique identifier for this plugin (`string`, default: `'ThumbnailGenerator'`).
 
 #### `locale`
 
@@ -95,7 +95,7 @@ export default {
 
 #### `thumbnailWidth`
 
-Width of the resulting thumbnail (`Number`, default: `200`). 
+Width of the resulting thumbnail (`number`, default: `200`). 
 
 Thumbnails are always proportional and not cropped.
 If width is provided, height is calculated automatically to match ratio.
@@ -103,7 +103,7 @@ If both width and height are given, only width is taken into account.
 
 #### `thumbnailHeight`
 
-Height of the resulting thumbnail (`Number`, default: `200`). 
+Height of the resulting thumbnail (`number`, default: `200`). 
 
 Thumbnails are always proportional and not cropped.
 If height is provided, width is calculated automatically to match ratio.
@@ -126,13 +126,13 @@ See issue [#979](https://github.com/transloadit/uppy/issues/979) and [#1096](htt
 
 #### `thumbnailType`
 
-MIME type of the resulting thumbnail (`String`, default: `'image/jpeg'`).
+MIME type of the resulting thumbnail (`string`, default: `'image/jpeg'`).
 
 This is useful if you want to support transparency in your thumbnails by switching to `image/png`.
 
 #### `waitForThumbnailsBeforeUpload`
 
-Whether to wait for all thumbnails to be ready before starting the upload (`Boolean`, default: `false`).
+Whether to wait for all thumbnails to be ready before starting the upload (`boolean`, default: `false`).
 
 If set to `true`, Thumbnail Generator will invoke Uppy’s internal processing stage and wait for `thumbnail:all-generated` event, before proceeding to the uploading stage.
 This is useful because Thumbnail Generator also adds EXIF data to images, and if we wait until it’s done processing, this data will be available on the server after the upload.


### PR DESCRIPTION
Typically, the capitalised version (e.g. `String`) refers to instances of the class (e.g. `new String`), when in fact the docs mean to refer to the primitive type (e.g. `'a primitive string'`).