### PR TITLE
meta: enable `proseWrap: always` Prettier option

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -32,7 +32,8 @@ jobs:
         run: npx envinfo
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir=$(corepack yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+        run:
+          echo "dir=$(corepack yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,6 @@
 module.exports = {
+	proseWrap: 'always',
+	singleQuote: true,
 	trailingComma: 'all',
 	useTabs: true,
-	singleQuote: true,
 };

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Website and documentation for [uppy](https://uppy.io/).
 
-This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+This website is built using [Docusaurus 2](https://docusaurus.io/), a modern
+static website generator.
 
 ## Developer guide
 
@@ -18,7 +19,8 @@ corepack yarn
 corepack yarn dev
 ```
 
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
+This command starts a local development server and opens up a browser window.
+Most changes are reflected live without having to restart the server.
 
 ### Build
 
@@ -26,4 +28,5 @@ This command starts a local development server and opens up a browser window. Mo
 corepack yarn build
 ```
 
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
+This command generates static content into the `build` directory and can be
+served using any static contents hosting service.

--- a/blog/2019-05-28-first-blog-post.md
+++ b/blog/2019-05-28-first-blog-post.md
@@ -9,4 +9,6 @@ authors:
 tags: [hola, docusaurus]
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum
+dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem
+ipsum dolor sit amet

--- a/blog/2019-05-29-long-blog-post.md
+++ b/blog/2019-05-29-long-blog-post.md
@@ -11,34 +11,66 @@ Use a `<!--` `truncate` `-->` comment to limit blog post size in the list view.
 
 <!--truncate-->
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum
+dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem
+ipsum dolor sit amet
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum
+dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem
+ipsum dolor sit amet
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum
+dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem
+ipsum dolor sit amet
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum
+dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem
+ipsum dolor sit amet
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum
+dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem
+ipsum dolor sit amet
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum
+dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem
+ipsum dolor sit amet
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum
+dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem
+ipsum dolor sit amet
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum
+dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem
+ipsum dolor sit amet
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum
+dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem
+ipsum dolor sit amet
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum
+dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem
+ipsum dolor sit amet
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum
+dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem
+ipsum dolor sit amet
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum
+dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem
+ipsum dolor sit amet
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum
+dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem
+ipsum dolor sit amet
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum
+dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem
+ipsum dolor sit amet
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum
+dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem
+ipsum dolor sit amet
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum
+dignissim ultricies. Fusce rhoncus ipsum tempor e\*os aliquam consequat. Lorem
+ipsum dolor sit amet

--- a/blog/2021-08-01-mdx-blog-post.mdx
+++ b/blog/2021-08-01-mdx-blog-post.mdx
@@ -5,7 +5,9 @@ authors: [slorber]
 tags: [docusaurus]
 ---
 
-Blog posts support [Docusaurus Markdown features](https://docusaurus.io/docs/markdown-features), such as [MDX](https://mdxjs.com/).
+Blog posts support
+[Docusaurus Markdown features](https://docusaurus.io/docs/markdown-features),
+such as [MDX](https://mdxjs.com/).
 
 :::tip
 

--- a/blog/2021-08-26-welcome/index.md
+++ b/blog/2021-08-26-welcome/index.md
@@ -5,7 +5,9 @@ authors: [slorber, yangshun]
 tags: [facebook, hello, docusaurus]
 ---
 
-[Docusaurus blogging features](https://docusaurus.io/docs/blog) are powered by the [blog plugin](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-blog).
+[Docusaurus blogging features](https://docusaurus.io/docs/blog) are powered by
+the
+[blog plugin](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-blog).
 
 S\*mply add Markdown files (or folders) to the `blog` directory.
 
@@ -22,4 +24,5 @@ A blog post folder can be convenient to co-locate blog post images:
 
 The blog supports tags as well!
 
-**And if you don’t want a blog**: remove this directory, and use `blog: false` in your Docusaurus config.
+**And if you don’t want a blog**: remove this directory, and use `blog: false`
+in your Docusaurus config.

--- a/docs/companion.md
+++ b/docs/companion.md
@@ -4,66 +4,89 @@ sidebar_position: 4
 
 # Companion
 
-Companion is an open source server application which **takes away the complexity of authentication
-and the cost of downloading files from remote sources**, such as Instagram, Google Drive, and others.
-Companion is a server-to-server orchestrator that streams files from a source to a destination, and files are never stored in Companion.
-Companion can run either as a standalone (self-hosted) application, [Transloadit-hosted](#hosted), or plugged in as an Express middleware
-into an existing application.
-The Uppy client requests remote files from Companion, which it will download and simultaneously upload to your [Tus server](/docs/upload-strategies/tus),
-[AWS bucket](/docs/upload-strategies/aws-s3), or any server that supports [PUT, POST or Multipart uploads](/docs/upload-strategies/xhr).
+Companion is an open source server application which **takes away the complexity
+of authentication and the cost of downloading files from remote sources**, such
+as Instagram, Google Drive, and others. Companion is a server-to-server
+orchestrator that streams files from a source to a destination, and files are
+never stored in Companion. Companion can run either as a standalone
+(self-hosted) application, [Transloadit-hosted](#hosted), or plugged in as an
+Express middleware into an existing application. The Uppy client requests remote
+files from Companion, which it will download and simultaneously upload to your
+[Tus server](/docs/upload-strategies/tus),
+[AWS bucket](/docs/upload-strategies/aws-s3), or any server that supports
+[PUT, POST or Multipart uploads](/docs/upload-strategies/xhr).
 
-This means a user uploading a 5GB video from Google Drive from their phone isn’t eating into their data plans and you don’t have to worry about implementing OAuth.
+This means a user uploading a 5GB video from Google Drive from their phone isn’t
+eating into their data plans and you don’t have to worry about implementing
+OAuth.
 
 ## When should I use it?
 
-If you want to let users download files from [Box][], [Dropbox][], [Facebook][], [Google Drive][googledrive], [Instagram][],
-[OneDrive][], [Unsplash][], [Import from URL][url], or [Zoom][] — you need Companion.
+If you want to let users download files from [Box][], [Dropbox][], [Facebook][],
+[Google Drive][googledrive], [Instagram][], [OneDrive][], [Unsplash][], [Import
+from URL][url], or [Zoom][] — you need Companion.
 
-Companion supports the same [uploaders](/docs/guides/choosing-upload-strategy) as Uppy:
-[Tus](/docs/upload-strategies/tus), [AWS S3](/docs/upload-strategies/aws-s3), and [regular multipart](/docs/upload-strategies/tus). But instead of manually setting a plugin,
-Uppy sends along a header with the uploader and Companion will use the same on the server.
-This means if you are using [Tus](/docs/uploaders/tus) for your local uploads, you can send your remote uploads
-to the same Tus server (and likewise for your AWS S3 bucket).
+Companion supports the same [uploaders](/docs/guides/choosing-upload-strategy)
+as Uppy: [Tus](/docs/upload-strategies/tus),
+[AWS S3](/docs/upload-strategies/aws-s3), and
+[regular multipart](/docs/upload-strategies/tus). But instead of manually
+setting a plugin, Uppy sends along a header with the uploader and Companion will
+use the same on the server. This means if you are using
+[Tus](/docs/uploaders/tus) for your local uploads, you can send your remote
+uploads to the same Tus server (and likewise for your AWS S3 bucket).
 
 :::note
-Companion only deals with _remote_ files, _local_ files are still uploaded from the client
-with your upload plugin.
+
+Companion only deals with _remote_ files, _local_ files are still uploaded from
+the client with your upload plugin.
+
 :::
 
 ## Hosted
 
-Using [Transloadit][] services comes with a hosted version of Companion so you don’t have to worry about hosting your own server.
-Whether you are on a free or paid Transloadit [plan](https://transloadit.com/pricing/), you can use Companion.
-It’s not possible to rent a Companion server without a Transloadit plan.
+Using [Transloadit][] services comes with a hosted version of Companion so you
+don’t have to worry about hosting your own server. Whether you are on a free or
+paid Transloadit [plan](https://transloadit.com/pricing/), you can use
+Companion. It’s not possible to rent a Companion server without a Transloadit
+plan.
 
 [**Sign-up for a (free) plan**](https://transloadit.com/pricing/).
 
 :::tip
-Choosing Transloadit for your file services also comes with credentials for all remote providers.
-This means you don’t have to waste time going through the approval process of every app.
-You can still add your own credentials in the Transloadit admin page if you want.
+
+Choosing Transloadit for your file services also comes with credentials for all
+remote providers. This means you don’t have to waste time going through the
+approval process of every app. You can still add your own credentials in the
+Transloadit admin page if you want.
+
 :::
 
 :::info
-Downloading and uploading files through Companion doesn’t count towards
-your [monthly quota](https://transloadit.com/docs/faq/1gb-worth/),
-it’s a way for files to arrive at Transloadit servers, much like Uppy.
+
+Downloading and uploading files through Companion doesn’t count towards your
+[monthly quota](https://transloadit.com/docs/faq/1gb-worth/), it’s a way for
+files to arrive at Transloadit servers, much like Uppy.
+
 :::
 
 ## Installation & use
 
-Companion is installed from npm. Depending on how you want to run Companion, the install process is slightly different. Companion can be integrated as middleware into your [Express](https://expressjs.com/) app or as a standalone server.
+Companion is installed from npm. Depending on how you want to run Companion, the
+install process is slightly different. Companion can be integrated as middleware
+into your [Express](https://expressjs.com/) app or as a standalone server.
 
 ```bash
 npm install @uppy/companion
 ```
 
 :::note
-Since v2, you need to be running `node.js >= v10.20.1` to use Companion.
-More information in the [migrating to 2.0](/docs/guides/migrate-2.0) guide.
 
-Windows is not a supported platform right now.
-It may work, and we’re happy to accept improvements in this area, but we can’t provide support.
+Since v2, you need to be running `node.js >= v10.20.1` to use Companion. More
+information in the [migrating to 2.0](/docs/guides/migrate-2.0) guide.
+
+Windows is not a supported platform right now. It may work, and we’re happy to
+accept improvements in this area, but we can’t provide support.
+
 :::
 
 ### Express middleware
@@ -74,9 +97,9 @@ First install it into your Node.js project with your favorite package manger:
 npm install @uppy/companion
 ```
 
-To plug Companion into an existing server, call its `.app` method,
-passing in an [options](#options) object as a parameter.
-This returns a server instance that you can mount on a route in your Express app.
+To plug Companion into an existing server, call its `.app` method, passing in an
+[options](#options) object as a parameter. This returns a server instance that
+you can mount on a route in your Express app.
 
 ```js
 import express from 'express';
@@ -113,8 +136,8 @@ const options = {
 app.use('/companion', companion.app(options));
 ```
 
-Companion uses WebSockets to communicate progress, errors, and successes to the client.
-This is what Uppy listens to to update it’s internal state and UI.
+Companion uses WebSockets to communicate progress, errors, and successes to the
+client. This is what Uppy listens to to update it’s internal state and UI.
 
 Add the Companion WebSocket server using the `companion.socket` function:
 
@@ -124,25 +147,32 @@ const server = app.listen(PORT);
 companion.socket(server);
 ```
 
-If WebSockets fail for some reason Uppy and Companion will fallback to HTTP polling.
+If WebSockets fail for some reason Uppy and Companion will fallback to HTTP
+polling.
 
 ### Standalone
 
-You can use the standalone version if you want to run Companion as it’s own Node process.
-It’s a configured Express server with sessions, logging, and security best practices.
-First you’ll typically want to install it globally:
+You can use the standalone version if you want to run Companion as it’s own Node
+process. It’s a configured Express server with sessions, logging, and security
+best practices. First you’ll typically want to install it globally:
 
 ```bash
 npm install -g @uppy/companion
 ```
 
-Standalone Companion will always serve HTTP (not HTTPS) and expects a reverse proxy with SSL termination in front of it when running in production. See [`COMPANION_PROTOCOL`](#server) for more information.
+Standalone Companion will always serve HTTP (not HTTPS) and expects a reverse
+proxy with SSL termination in front of it when running in production. See
+[`COMPANION_PROTOCOL`](#server) for more information.
 
-Companion ships with an excecutable file (`bin/companion`) which is the standalone server.
-Unlike the middleware version, options are set via environment variables.
+Companion ships with an excecutable file (`bin/companion`) which is the
+standalone server. Unlike the middleware version, options are set via
+environment variables.
 
 :::info
-Checkout [options](#options) for the available options in JS and environment variable formats.
+
+Checkout [options](#options) for the available options in JS and environment
+variable formats.
+
 :::
 
 You need at least these three to get started:
@@ -165,58 +195,76 @@ You can also pass in the path to your JSON config file, like so:
 companion --config /path/to/companion.json
 ```
 
-You may also want to run Companion in a process manager like [PM2](https://pm2.keymetrics.io/) to make sure it gets restarted on upon crashing as well as allowing scaling to many instances.
+You may also want to run Companion in a process manager like
+[PM2](https://pm2.keymetrics.io/) to make sure it gets restarted on upon
+crashing as well as allowing scaling to many instances.
 
 ### Running many instances
 
-We recommend running at least two instances in production,
-so that if the Node.js event loop gets blocked by one or more requests (due to a bug or spike in traffic),
-it doesn’t also block or slow down all other requests as well (as Node.js is single threaded).
+We recommend running at least two instances in production, so that if the
+Node.js event loop gets blocked by one or more requests (due to a bug or spike
+in traffic), it doesn’t also block or slow down all other requests as well (as
+Node.js is single threaded).
 
-As an example for scale, one enterprise customer of Transloadit,
-who self-hosts Companion to power an education service that is used by many universities globally, deploys 7 Companion instances.
-Their earlier solution ran on 35 instances.
-In our general experience Companion will saturate network interface cards before other resources on commodity virtual servers (`c5d.2xlarge` for instance).
+As an example for scale, one enterprise customer of Transloadit, who self-hosts
+Companion to power an education service that is used by many universities
+globally, deploys 7 Companion instances. Their earlier solution ran on 35
+instances. In our general experience Companion will saturate network interface
+cards before other resources on commodity virtual servers (`c5d.2xlarge` for
+instance).
 
-Your mileage may vary, so we recommend to add observability.
-You can let Prometheus crawl the `/metrics` endpoint and graph that with Grafana for instance.
+Your mileage may vary, so we recommend to add observability. You can let
+Prometheus crawl the `/metrics` endpoint and graph that with Grafana for
+instance.
 
 #### Using unique endpoints
 
-One option is to run many instances with each instance having its own unique endpoint.
-This could be on separate ports, (sub)domain names, or IPs. With this setup, you can either:
+One option is to run many instances with each instance having its own unique
+endpoint. This could be on separate ports, (sub)domain names, or IPs. With this
+setup, you can either:
 
-1. Implement your own logic that will direct each upload to a specific Companion endpoint by setting the `companionUrl` option
-2. Setting the Companion option `COMPANION_SELF_ENDPOINT`.
-   This option will cause Companion to respond with a `i-am` HTTP header containing the value from `COMPANION_SELF_ENDPOINT`.
-   When Uppy’s sees this header, it will pin all requests for the upload to this endpoint.
+1. Implement your own logic that will direct each upload to a specific Companion
+   endpoint by setting the `companionUrl` option
+2. Setting the Companion option `COMPANION_SELF_ENDPOINT`. This option will
+   cause Companion to respond with a `i-am` HTTP header containing the value
+   from `COMPANION_SELF_ENDPOINT`. When Uppy’s sees this header, it will pin all
+   requests for the upload to this endpoint.
 
-In either case, you would then also typically configure a single Companion instance (one endpoint)
-to handle all OAuth authentication requests, so that you only need to specify a single OAuth callback URL.
-See also `oauthDomain` and `validHosts`.
+In either case, you would then also typically configure a single Companion
+instance (one endpoint) to handle all OAuth authentication requests, so that you
+only need to specify a single OAuth callback URL. See also `oauthDomain` and
+`validHosts`.
 
 #### Using a load balancer
 
-The other option is to set up a load balancer in front of many Companion instances.
-Then Uppy will only see a single endpoint and send all requests to the associated load balancer,
-which will then distribute them between Companion instances.
-The companion instances coordinate their messages and events over Redis so that any instance can serve the client’s requests.
-Note that sticky sessions are **not** needed with this setup. Here are the requirements for this setup:
+The other option is to set up a load balancer in front of many Companion
+instances. Then Uppy will only see a single endpoint and send all requests to
+the associated load balancer, which will then distribute them between Companion
+instances. The companion instances coordinate their messages and events over
+Redis so that any instance can serve the client’s requests. Note that sticky
+sessions are **not** needed with this setup. Here are the requirements for this
+setup:
 
 - The instances need to be connected to the same Redis server.
 - You need to set `COMPANION_SECRET` to the same value on both servers.
-- if you use the `companionKeysParams` feature (Transloadit), you also need `COMPANION_PREAUTH_SECRET` to be the same on each instance.
-- All other configuration needs to be the same, except if you’re running many instances on the same machine, then `COMPANION_PORT` should be different for each instance.
+- if you use the `companionKeysParams` feature (Transloadit), you also need
+  `COMPANION_PREAUTH_SECRET` to be the same on each instance.
+- All other configuration needs to be the same, except if you’re running many
+  instances on the same machine, then `COMPANION_PORT` should be different for
+  each instance.
 
 ## API
 
 ### Options
 
 :::tip
-The headings display the JS and environment variable options (`option` `ENV_OPTION`).
-When integrating Companion into your own server, you pass the options to `companion.app()`.
-If you are using the standalone version, you configure Companion using environment variables.
-Some options only exist as environment variables or only as a JS option.
+
+The headings display the JS and environment variable options (`option`
+`ENV_OPTION`). When integrating Companion into your own server, you pass the
+options to `companion.app()`. If you are using the standalone version, you
+configure Companion using environment variables. Some options only exist as
+environment variables or only as a JS option.
+
 :::
 
 <details>
@@ -249,12 +297,13 @@ const options = {
 
 #### `filePath` `COMPANION_DATADIR`
 
-Full path to the directory to which provider files will be downloaded temporarily.
+Full path to the directory to which provider files will be downloaded
+temporarily.
 
 #### `secret` `COMPANION_SECRET` `COMPANION_SECRET_FILE`
 
-A secret string which Companion uses to generate authorization tokens.
-You should generate a long random string for this. For example:
+A secret string which Companion uses to generate authorization tokens. You
+should generate a long random string for this. For example:
 
 ```js
 const crypto = require('crypto');
@@ -263,29 +312,40 @@ const secret = crypto.randomBytes(64).toString('hex');
 ```
 
 :::caution
+
 Omitting the `secret` in the standalone version will generate a secret for you,
-using the above `crypto` string. But when integrating with Express you must provide it yourself.
-This is an essential security measure.
+using the above `crypto` string. But when integrating with Express you must
+provide it yourself. This is an essential security measure.
+
 :::
 
 :::note
+
 Using a secret file means passing an absolute path to a file with any extension,
 which has only the secret, nothing else.
+
 :::
 
 #### `preAuthSecret` `COMPANION_PREAUTH_SECRET` `COMPANION_PREAUTH_SECRET_FILE`
 
-If you are using the [Transloadit](/docs/upload-strategies/transloadit) `companionKeysParams` feature (Transloadit-hosted Companion using your own custom OAuth credentials),
-set this variable to a strong randomly generated secret. See also `COMPANION_SECRET` (but do not use the same secret!)
+If you are using the [Transloadit](/docs/upload-strategies/transloadit)
+`companionKeysParams` feature (Transloadit-hosted Companion using your own
+custom OAuth credentials), set this variable to a strong randomly generated
+secret. See also `COMPANION_SECRET` (but do not use the same secret!)
 
 :::note
+
 Using a secret file means passing an absolute path to a file with any extension,
 which has only the secret, nothing else.
+
 :::
 
 #### `uploadUrls` `COMPANION_UPLOAD_URLS`
 
-An allowlist (array) of strings (exact URLs) or regular expressions. Companion will only accept uploads to these URLs. This ensures that your Companion instance is only allowed to upload to your trusted servers and prevents [SSRF](https://en.wikipedia.org/wiki/Server-side_request_forgery) attacks.
+An allowlist (array) of strings (exact URLs) or regular expressions. Companion
+will only accept uploads to these URLs. This ensures that your Companion
+instance is only allowed to upload to your trusted servers and prevents
+[SSRF](https://en.wikipedia.org/wiki/Server-side_request_forgery) attacks.
 
 #### `COMPANION_PORT`
 
@@ -301,17 +361,19 @@ Setting this to `true` disables the welcome message shown at `/`.
 
 #### `redisUrl` `COMPANION_REDIS_URL`
 
-URL to running Redis server. This can be used to scale Companion horizontally using many instances. See [How to scale Companion](#how-to-scale-companion).
+URL to running Redis server. This can be used to scale Companion horizontally
+using many instances. See [How to scale Companion](#how-to-scale-companion).
 
 #### `redisOptions`
 
-An object of [options supported by redis client](https://www.npmjs.com/package/redis#options-object-properties).
+An object of
+[options supported by redis client](https://www.npmjs.com/package/redis#options-object-properties).
 This option can be used in place of `redisUrl`.
 
 #### `redisPubSubScope`
 
-Use a scope for the companion events at the Redis server.
-Setting this option will prefix all events with the name provided and a colon.
+Use a scope for the companion events at the Redis server. Setting this option
+will prefix all events with the name provided and a colon.
 
 #### `server`
 
@@ -328,8 +390,9 @@ Configuation options for the underlying server.
 
 #### `sendSelfEndpoint` `COMPANION_SELF_ENDPOINT`
 
-This is essentially the same as the `server.host + server.path` attributes.
-The major reason for this attribute is that, when set, it adds the value as the `i-am` header of every request response.
+This is essentially the same as the `server.host + server.path` attributes. The
+major reason for this attribute is that, when set, it adds the value as the
+`i-am` header of every request response.
 
 #### `providerOptions`
 
@@ -344,11 +407,14 @@ Object to enable providers with their keys and secrets. For example:
 }
 ```
 
-When using the standalone version you use the corresponding environment variables
-or point to a secret file (such as `COMPANION_GOOGLE_SECRET_FILE`).
+When using the standalone version you use the corresponding environment
+variables or point to a secret file (such as `COMPANION_GOOGLE_SECRET_FILE`).
 
 :::note
-Secret files need an absolute path to a file with any extension which only has the secret, nothing else.
+
+Secret files need an absolute path to a file with any extension which only has
+the secret, nothing else.
+
 :::
 
 | Service      | Key         | Environment variables                                                                                                                                                                                                                  |
@@ -363,9 +429,10 @@ Secret files need an absolute path to a file with any extension which only has t
 
 #### `s3`
 
-Companion comes with signature endpoints for AWS S3.
-These can be used by the Uppy client to sign requests to upload files directly to S3, without exposing secret S3 keys in the browser.
-Companion also supports uploading files from providers like Dropbox and Instagram directly into S3.
+Companion comes with signature endpoints for AWS S3. These can be used by the
+Uppy client to sign requests to upload files directly to S3, without exposing
+secret S3 keys in the browser. Companion also supports uploading files from
+providers like Dropbox and Instagram directly into S3.
 
 ##### `s3.key` `COMPANION_AWS_KEY`
 
@@ -376,8 +443,10 @@ The S3 access key ID.
 The S3 secret access key.
 
 :::note
+
 Using a secret file means passing an absolute path to a file with any extension,
 which has only the secret, nothing else.
+
 :::
 
 ##### `s3.bucket` `COMPANION_AWS_BUCKET`
@@ -390,30 +459,39 @@ The datacenter region where the target bucket is located.
 
 ##### `s3.awsClientOptions`
 
-You can supply any [S3 option supported by the AWS SDK](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property)
+You can supply any
+[S3 option supported by the AWS SDK](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property)
 in the `providerOptions.s3.awsClientOptions` object, _except for_ the below:
 
-- `accessKeyId`. Instead, use the `providerOptions.s3.key` property.
-  This is to make configuration names consistent between different Companion features.
-- `secretAccessKey`. Instead, use the `providerOptions.s3.secret` property.
-  This is to make configuration names consistent between different Companion features.
+- `accessKeyId`. Instead, use the `providerOptions.s3.key` property. This is to
+  make configuration names consistent between different Companion features.
+- `secretAccessKey`. Instead, use the `providerOptions.s3.secret` property. This
+  is to make configuration names consistent between different Companion
+  features.
 
-Be aware that some options may cause wrong behaviour if they conflict with Companion’s assumptions.
-If you find that a particular option does not work as expected, please [open an issue on the Uppy repository](https://github.com/transloadit/uppy/issues/new) so we can document it here.
+Be aware that some options may cause wrong behaviour if they conflict with
+Companion’s assumptions. If you find that a particular option does not work as
+expected, please
+[open an issue on the Uppy repository](https://github.com/transloadit/uppy/issues/new)
+so we can document it here.
 
 ##### `s3.getKey(req, filename, metadata)`
 
-Get the key name for a file. The key is the file path to which the file will be uploaded in your bucket.
-This option should be a function receiving three arguments:
+Get the key name for a file. The key is the file path to which the file will be
+uploaded in your bucket. This option should be a function receiving three
+arguments:
 
-- `req`, the HTTP request, for _regular_ S3 uploads using the `@uppy/aws-s3` plugin.
-  This parameter is _not_ available for multipart uploads using the `@uppy/aws-s3-multipart` plugin;
+- `req`, the HTTP request, for _regular_ S3 uploads using the `@uppy/aws-s3`
+  plugin. This parameter is _not_ available for multipart uploads using the
+  `@uppy/aws-s3-multipart` plugin;
 - `filename`, the original name of the uploaded file;
-- `metadata`, user-provided metadata for the file.
-  See the [`@uppy/aws-s3`](https://uppy.io/docs/aws-s3/#metaFields) docs. The `@uppy/aws-s3-multipart` plugin unconditionally sends all metadata fields, so they all are available here.
+- `metadata`, user-provided metadata for the file. See the
+  [`@uppy/aws-s3`](https://uppy.io/docs/aws-s3/#metaFields) docs. The
+  `@uppy/aws-s3-multipart` plugin unconditionally sends all metadata fields, so
+  they all are available here.
 
-This function should return a string `key`.
-The `req` parameter can be used to upload to a user-specific folder in your bucket, for example:
+This function should return a string `key`. The `req` parameter can be used to
+upload to a user-specific folder in your bucket, for example:
 
 ```js
 app.use(authenticationMiddleware);
@@ -429,8 +507,8 @@ app.use(
 );
 ```
 
-The default implementation returns the `filename`,
-so all files will be uploaded to the root of the bucket as their original file name.
+The default implementation returns the `filename`, so all files will be uploaded
+to the root of the bucket as their original file name.
 
 ```js
 app.use(
@@ -446,20 +524,25 @@ app.use(
 
 #### `COMPANION_AWS_USE_ACCELERATE_ENDPOINT`
 
-Enable S3 [Transfer Acceleration](https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration.html).
+Enable S3
+[Transfer Acceleration](https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration.html).
 
 #### `COMPANION_AWS_EXPIRES`
 
-Set `X-Amz-Expires` query parameter in the presigned urls (in seconds, default: 300).
+Set `X-Amz-Expires` query parameter in the presigned urls (in seconds, default:
+300).
 
 #### `COMPANION_AWS_ACL`
 
-Set a [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) for uploaded objects.
+Set a
+[Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl)
+for uploaded objects.
 
 #### `customProviders`
 
-This option enables you to add custom providers along with the already supported providers.
-See [adding custom providers](#how-to-add-custom-providers) for more information.
+This option enables you to add custom providers along with the already supported
+providers. See [adding custom providers](#how-to-add-custom-providers) for more
+information.
 
 #### `logClientVersion`
 
@@ -467,25 +550,27 @@ A boolean flag to tell Companion whether to log its version upon startup.
 
 #### `metrics` `COMPANION_HIDE_METRICS`
 
-A boolean flag to tell Companion whether to provide an endpoint `/metrics` with Prometheus metrics (by default metrics are enabled.)
+A boolean flag to tell Companion whether to provide an endpoint `/metrics` with
+Prometheus metrics (by default metrics are enabled.)
 
 #### `streamingUpload` `COMPANION_STREAMING_UPLOAD`
 
-A boolean flag to tell Companion whether to enable streaming uploads.
-If enabled, it will lead to _faster uploads_ because companion will start uploading at the same time as downloading using `stream.pipe`.
-If `false`, files will be fully downloaded first, then uploaded. Defaults to `false`,
-but we recommended enabling it, especially if you’re expecting to upload large files.
-In future versions the default might change to `true`.
+A boolean flag to tell Companion whether to enable streaming uploads. If
+enabled, it will lead to _faster uploads_ because companion will start uploading
+at the same time as downloading using `stream.pipe`. If `false`, files will be
+fully downloaded first, then uploaded. Defaults to `false`, but we recommended
+enabling it, especially if you’re expecting to upload large files. In future
+versions the default might change to `true`.
 
 #### `maxFileSize` `COMPANION_MAX_FILE_SIZE`
 
-If this value is set, companion will limit the maximum file size to process.
-If unset, it will process files without any size limit (this is the default).
+If this value is set, companion will limit the maximum file size to process. If
+unset, it will process files without any size limit (this is the default).
 
 #### `periodicPingUrls` `COMPANION_PERIODIC_PING_URLS`
 
-If this value is set, companion will periodically send POST requests to the specified URLs.
-Useful for keeping track of companion instances as a keep-alive.
+If this value is set, companion will periodically send POST requests to the
+specified URLs. Useful for keeping track of companion instances as a keep-alive.
 
 #### `periodicPingInterval` `COMPANION_PERIODIC_PING_INTERVAL`
 
@@ -493,20 +578,25 @@ Interval for periodic ping requests (in ms).
 
 #### `periodicPingStaticPayload` `COMPANION_PERIODIC_PING_STATIC_JSON_PAYLOAD`
 
-A `JSON.stringify`-able JavaScript Object that will be sent as part of the JSON body in the period ping requests.
+A `JSON.stringify`-able JavaScript Object that will be sent as part of the JSON
+body in the period ping requests.
 
 #### `allowLocalUrls` `COMPANION_ALLOW_LOCAL_URLS`
 
-A boolean flag to tell Companion whether to allow requesting local URLs (non-internet IPs).
+A boolean flag to tell Companion whether to allow requesting local URLs
+(non-internet IPs).
 
 :::caution
-Only enable this in development. **Enabling it in production is a security risk.**
+
+Only enable this in development. **Enabling it in production is a security
+risk.**
+
 :::
 
 #### `corsOrigins` `COMPANION_CLIENT_ORIGINS`
 
-Allowed CORS Origins (default `true`).
-Passed as the `origin` option in [cors](https://github.com/expressjs/cors#configuration-options))
+Allowed CORS Origins (default `true`). Passed as the `origin` option in
+[cors](https://github.com/expressjs/cors#configuration-options))
 
 #### `COMPANION_CLIENT_ORIGINS_REGEX`
 
@@ -515,17 +605,23 @@ Like COMPANION_CLIENT_ORIGINS, but allows a single regex instead.
 
 #### `chunkSize` `COMPANION_CHUNK_SIZE`
 
-Controls how big the uploaded chunks are for AWS S3 Multipart and Tus.
-Smaller values lead to more overhead, but larger values lead to slower retries in case of bad network connections.
-Passed to tus-js-client [`chunkSize`](https://github.com/tus/tus-js-client/blob/master/docs/api.md#chunksize) as well as [AWS S3 Multipart](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html) `partSize`.
+Controls how big the uploaded chunks are for AWS S3 Multipart and Tus. Smaller
+values lead to more overhead, but larger values lead to slower retries in case
+of bad network connections. Passed to tus-js-client
+[`chunkSize`](https://github.com/tus/tus-js-client/blob/master/docs/api.md#chunksize)
+as well as
+[AWS S3 Multipart](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html)
+`partSize`.
 
 ### Events
 
-The object returned by `companion.app()` also has a property `companionEmitter` which is an `EventEmitter`
-that emits the following events:
+The object returned by `companion.app()` also has a property `companionEmitter`
+which is an `EventEmitter` that emits the following events:
 
-- `upload-start` - When an upload starts, this event is emitted with an object containing the property `token`, which is a unique ID for the upload.
-- **token** - The event name is the token from `upload-start`. The event has an object with the following properties:
+- `upload-start` - When an upload starts, this event is emitted with an object
+  containing the property `token`, which is a unique ID for the upload.
+- **token** - The event name is the token from `upload-start`. The event has an
+  object with the following properties:
   - `action` - One of the following strings:
     - `success` - When the upload succeeds.
     - `error` - When the upload fails with an error.
@@ -563,41 +659,71 @@ An example server is running at <https://companion.uppy.io>.
 
 ### How does the Authentication and Token mechanism work?
 
-This section describes how Authentication works between Companion and Providers. While this behaviour is the same for all Providers (Dropbox, Instagram, Google Drive, etc.), we are going to be referring to Dropbox in place of any Provider throughout this section.
+This section describes how Authentication works between Companion and Providers.
+While this behaviour is the same for all Providers (Dropbox, Instagram, Google
+Drive, etc.), we are going to be referring to Dropbox in place of any Provider
+throughout this section.
 
-The following steps describe the actions that take place when a user Authenticates and Uploads from Dropbox through Companion:
+The following steps describe the actions that take place when a user
+Authenticates and Uploads from Dropbox through Companion:
 
 - The visitor to a website with Uppy clicks `Connect to Dropbox`.
-- Uppy sends a request to Companion, which in turn sends an OAuth request to Dropbox (Requires that OAuth credentials from Dropbox have been added to Companion).
-- Dropbox asks the visitor to log in, and whether the Website should be allowed to access your files
-- If the visitor agrees, Companion will receive a token from Dropbox, with which we can temporarily download files.
-- Companion encrypts the token with a secret key and sends the encrypted token to Uppy (client)
-- Every time the visitor clicks on a folder in Uppy, it asks Companion for the new list of files, with this question, the token (still encrypted by Companion) is sent along.
-- Companion decrypts the token, requests the list of files from Dropbox and sends it to Uppy.
-- When a file is selected for upload, Companion receives the token again according to this procedure, decrypts it again, and thereby downloads the file from Dropbox.
-- As the bytes arrive, Companion uploads the bytes to the final destination (depending on the configuration: Apache, a Tus server, S3 bucket, etc).
+- Uppy sends a request to Companion, which in turn sends an OAuth request to
+  Dropbox (Requires that OAuth credentials from Dropbox have been added to
+  Companion).
+- Dropbox asks the visitor to log in, and whether the Website should be allowed
+  to access your files
+- If the visitor agrees, Companion will receive a token from Dropbox, with which
+  we can temporarily download files.
+- Companion encrypts the token with a secret key and sends the encrypted token
+  to Uppy (client)
+- Every time the visitor clicks on a folder in Uppy, it asks Companion for the
+  new list of files, with this question, the token (still encrypted by
+  Companion) is sent along.
+- Companion decrypts the token, requests the list of files from Dropbox and
+  sends it to Uppy.
+- When a file is selected for upload, Companion receives the token again
+  according to this procedure, decrypts it again, and thereby downloads the file
+  from Dropbox.
+- As the bytes arrive, Companion uploads the bytes to the final destination
+  (depending on the configuration: Apache, a Tus server, S3 bucket, etc).
 - Companion reports progress to Uppy, as if it were a local upload.
 - Completed!
 
 ### How to use provider redirect URIs?
 
-When generating your provider API keys on their corresponding developer platforms (e.g [Google Developer Console](https://console.developers.google.com/)), you’d need to provide a `redirect URI` for the OAuth authorization process. In general the redirect URI for each provider takes the format:
+When generating your provider API keys on their corresponding developer
+platforms (e.g
+[Google Developer Console](https://console.developers.google.com/)), you’d need
+to provide a `redirect URI` for the OAuth authorization process. In general the
+redirect URI for each provider takes the format:
 
 `http(s)://$YOUR_COMPANION_HOST_NAME/$PROVIDER_NAME/redirect`
 
-For example, if your Companion server is hosted on `https://my.companion.server.com`, then the redirect URI you would supply for your OneDrive provider would be:
+For example, if your Companion server is hosted on
+`https://my.companion.server.com`, then the redirect URI you would supply for
+your OneDrive provider would be:
 
 `https://my.companion.server.com/onedrive/redirect`
 
-Please see [Supported Providers](https://uppy.io/docs/companion/#Supported-providers) for a list of all Providers and their corresponding names.
+Please see
+[Supported Providers](https://uppy.io/docs/companion/#Supported-providers) for a
+list of all Providers and their corresponding names.
 
 ### How to use Companion with Kubernetes?
 
-We have a detailed [guide](https://github.com/transloadit/uppy/blob/main/packages/%40uppy/companion/KUBERNETES.md) on running Companion in Kubernetes.
+We have a detailed
+[guide](https://github.com/transloadit/uppy/blob/main/packages/%40uppy/companion/KUBERNETES.md)
+on running Companion in Kubernetes.
 
 ### How to add custom providers?
 
-As of now, Companion supports the [providers listed here](https://uppy.io/docs/companion/#Supported-providers) out of the box, but you may also choose to add your own custom providers. You can do this by passing the `customProviders` option when calling the Uppy `app` method. The custom provider is expected to support Oauth 1 or 2 for authentication/authorization.
+As of now, Companion supports the
+[providers listed here](https://uppy.io/docs/companion/#Supported-providers) out
+of the box, but you may also choose to add your own custom providers. You can do
+this by passing the `customProviders` option when calling the Uppy `app` method.
+The custom provider is expected to support Oauth 1 or 2 for
+authentication/authorization.
 
 ```javascript
 import providerModule from './path/to/provider/module';
@@ -621,29 +747,53 @@ const options = {
 uppy.app(options);
 ```
 
-The `customProviders` option should be an object containing each custom provider. Each custom provider would, in turn, be an object with two keys, `config` and `module`. The `config` option would contain Oauth API settings, while the `module` would point to the provider module.
+The `customProviders` option should be an object containing each custom
+provider. Each custom provider would, in turn, be an object with two keys,
+`config` and `module`. The `config` option would contain Oauth API settings,
+while the `module` would point to the provider module.
 
-To work well with Companion, the **module** must be a class with the following methods. Note that the methods must be `async`, return a `Promise` or reject with an `Error`):
+To work well with Companion, the **module** must be a class with the following
+methods. Note that the methods must be `async`, return a `Promise` or reject
+with an `Error`):
 
-1. `async list ({ token, directory, query })` - Returns a object containing a list of user files (such as a list of all the files in a particular directory). See [example returned list data structure](#list-data).
-   `token` - authorization token (retrieved from oauth process) to send along with your request
-   - `directory` - the id/name of the directory from which data is to be retrieved. This may be ignored if it doesn’t apply to your provider
-   - `query` - expressjs query params object received by the server (in case some data you need in there).
-2. `async download ({ token, id, query })` - Downloads a particular file from the provider. Returns an object with a single property `{ stream }` - a [`stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable), which will be read from and uploaded to the destination. To prevent memory leaks, make sure you release your stream if you reject this method with an error.
-   - `token` - authorization token (retrieved from oauth process) to send along with your request.
+1. `async list ({ token, directory, query })` - Returns a object containing a
+   list of user files (such as a list of all the files in a particular
+   directory). See [example returned list data structure](#list-data). `token` -
+   authorization token (retrieved from oauth process) to send along with your
+   request
+   - `directory` - the id/name of the directory from which data is to be
+     retrieved. This may be ignored if it doesn’t apply to your provider
+   - `query` - expressjs query params object received by the server (in case
+     some data you need in there).
+2. `async download ({ token, id, query })` - Downloads a particular file from
+   the provider. Returns an object with a single property `{ stream }` - a
+   [`stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable),
+   which will be read from and uploaded to the destination. To prevent memory
+   leaks, make sure you release your stream if you reject this method with an
+   error.
+   - `token` - authorization token (retrieved from oauth process) to send along
+     with your request.
    - `id` - ID of the file being downloaded.
-   - `query` - expressjs query params object received by the server (in case some data you need in there).
-3. `async size ({ token, id, query })` - Returns the byte size of the file that needs to be downloaded as a `Number`. If the size of the object is not known, `null` may be returned.
-   - `token` - authorization token (retrieved from oauth process) to send along with your request.
+   - `query` - expressjs query params object received by the server (in case
+     some data you need in there).
+3. `async size ({ token, id, query })` - Returns the byte size of the file that
+   needs to be downloaded as a `Number`. If the size of the object is not known,
+   `null` may be returned.
+   - `token` - authorization token (retrieved from oauth process) to send along
+     with your request.
    - `id` - ID of the file being downloaded.
-   - `query` - expressjs query params object received by the server (in case some data you need in there).
+   - `query` - expressjs query params object received by the server (in case
+     some data you need in there).
 
 The class must also have:
 
-- A unique `authProvider` string property - a lowercased value which typically indicates the name of the provider (e.g “dropbox”).
-- A `static` property `static version = 2`, which is the current version of the Companion Provider API.
+- A unique `authProvider` string property - a lowercased value which typically
+  indicates the name of the provider (e.g “dropbox”).
+- A `static` property `static version = 2`, which is the current version of the
+  Companion Provider API.
 
-See also [example code with a custom provider](https://github.com/transloadit/uppy/blob/main/examples/custom-provider/server).
+See also
+[example code with a custom provider](https://github.com/transloadit/uppy/blob/main/examples/custom-provider/server).
 
 #### list data
 
@@ -689,7 +839,8 @@ See also [example code with a custom provider](https://github.com/transloadit/up
 
 ### How to run Companion locally?
 
-1\. To set up Companion for local development, please clone the Uppy repo and install, like so:
+1\. To set up Companion for local development, please clone the Uppy repo and
+install, like so:
 
 ```bash
 git clone https://github.com/transloadit/uppy
@@ -697,7 +848,8 @@ cd uppy
 yarn install
 ```
 
-2\. Configure your environment variables by copying the `env.example.sh` file to `env.sh` and edit it to its correct values.
+2\. Configure your environment variables by copying the `env.example.sh` file to
+`env.sh` and edit it to its correct values.
 
 ```bash
 cp env.example.sh env.sh
@@ -710,7 +862,9 @@ $EDITOR env.sh
 yarn run start:companion
 ```
 
-This would get the Companion instance running on `http://localhost:3020`. It uses [nodemon](https://github.com/remy/nodemon) so it will automatically restart when files are changed.
+This would get the Companion instance running on `http://localhost:3020`. It
+uses [nodemon](https://github.com/remy/nodemon) so it will automatically restart
+when files are changed.
 
 [box]: /docs/sources/companion-plugins/box
 [dropbox]: /docs/sources/companion-plugins/dropbox

--- a/docs/guides/browser-support.mdx
+++ b/docs/guides/browser-support.mdx
@@ -12,8 +12,8 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 We officially support recent versions of Chrome, Firefox, Safari and Edge.
 
 Internet Explorer is not officially supported, as in we don’t run tests for it,
-but you can be mostly confident it works with the right polyfills.
-But it does come with a risk of unexpected results in styling or functionality.
+but you can be mostly confident it works with the right polyfills. But it does
+come with a risk of unexpected results in styling or functionality.
 
 ## Polyfills
 

--- a/docs/guides/building-plugins.md
+++ b/docs/guides/building-plugins.md
@@ -4,30 +4,33 @@ sidebar_position: 3
 
 # Building plugins
 
-You can find already a few useful Uppy plugins out there,
-but there might come a time when you will want to build your own.
-Plugins can hook into the upload process or render a custom UI, typically to:
+You can find already a few useful Uppy plugins out there, but there might come a
+time when you will want to build your own. Plugins can hook into the upload
+process or render a custom UI, typically to:
 
-- Render some custom UI element, such as [StatusBar](/docs/statusbar) or [Dashboard](/docs/dashboard).
-- Do the actual uploading, such as [XHRUpload](/docs/xhrupload) or [Tus](/docs/tus).
+- Render some custom UI element, such as [StatusBar](/docs/statusbar) or
+  [Dashboard](/docs/dashboard).
+- Do the actual uploading, such as [XHRUpload](/docs/xhrupload) or
+  [Tus](/docs/tus).
 - Do work before the upload, like compressing an image or calling external API.
-- Interact with a third-party service to process uploads correctly,
-  such as [Transloadit](/docs/transloadit) or [AwsS3](/docs/aws-s3).
+- Interact with a third-party service to process uploads correctly, such as
+  [Transloadit](/docs/transloadit) or [AwsS3](/docs/aws-s3).
 
 See a [full example of a plugin](#Example-of-a-custom-plugin) below.
 
 ## Creating A Plugin
 
-Uppy has two classes to create plugins with. `BasePlugin` for plugins that don’t need a user interface,
-and `UIPlugin` for onces that do. Each plugin has an `id` and a `type`. `id`s are used to uniquely identify plugins.
-A `type` can be anything—some plugins use `type`s to decide whether to do something to some other plugin.
-For example, when targeting plugins at the built-in `Dashboard` plugin,
-the Dashboard uses the `type` to figure out where to mount different UI elements.
-`'acquirer'`-type plugins are mounted into the tab bar,
-while `'progressindicator'`-type plugins are mounted into the progress bar area.
+Uppy has two classes to create plugins with. `BasePlugin` for plugins that don’t
+need a user interface, and `UIPlugin` for onces that do. Each plugin has an `id`
+and a `type`. `id`s are used to uniquely identify plugins. A `type` can be
+anything—some plugins use `type`s to decide whether to do something to some
+other plugin. For example, when targeting plugins at the built-in `Dashboard`
+plugin, the Dashboard uses the `type` to figure out where to mount different UI
+elements. `'acquirer'`-type plugins are mounted into the tab bar, while
+`'progressindicator'`-type plugins are mounted into the progress bar area.
 
-The plugin constructor receives the Uppy instance in the first parameter,
-and any options passed to `uppy.use()` in the second parameter.
+The plugin constructor receives the Uppy instance in the first parameter, and
+any options passed to `uppy.use()` in the second parameter.
 
 ```js
 import BasePlugin from '@uppy/core/lib/BasePlugin.js';
@@ -43,8 +46,8 @@ export default class MyPlugin extends BasePlugin {
 
 ## Methods
 
-Plugins can define methods to execute certain tasks.
-The most important method is `install()`, which is called when a plugin is `.use`d.
+Plugins can define methods to execute certain tasks. The most important method
+is `install()`, which is called when a plugin is `.use`d.
 
 All the below methods are optional! Only define the methods you need.
 
@@ -52,8 +55,8 @@ All the below methods are optional! Only define the methods you need.
 
 #### `install()`
 
-Called when the plugin is `.use`d. Do any setup work here,
-like attaching events or adding [upload hooks](#Upload-Hooks).
+Called when the plugin is `.use`d. Do any setup work here, like attaching events
+or adding [upload hooks](#Upload-Hooks).
 
 ```js
 export default class MyPlugin extends UIPlugin {
@@ -67,8 +70,8 @@ export default class MyPlugin extends UIPlugin {
 
 #### `uninstall()`
 
-Called when the plugin is removed, or the Uppy instance is closed.
-This should undo all the work done in the `install()` method.
+Called when the plugin is removed, or the Uppy instance is closed. This should
+undo all the work done in the `install()` method.
 
 ```js
 export default class MyPlugin extends UIPlugin {
@@ -86,25 +89,28 @@ Called after every state update with a debounce, after everything has mounted.
 
 #### `addTarget()`
 
-Use this to add your plugin to another plugin’s target.
-This is what `@uppy/dashboard` uses to add other plugins to its UI.
+Use this to add your plugin to another plugin’s target. This is what
+`@uppy/dashboard` uses to add other plugins to its UI.
 
 ### `UIPlugin`
 
-`UIPlugin` extends the `BasePlugin` class so it will also contain all the above methods.
+`UIPlugin` extends the `BasePlugin` class so it will also contain all the above
+methods.
 
 #### `mount(target)`
 
-Mount this plugin to the `target` element. `target` can be a CSS query selector, a DOM element, or another Plugin.
-If `target` is a Plugin, the source (current) plugin will register with the target plugin,
-and the latter can decide how and where to render the source plugin.
+Mount this plugin to the `target` element. `target` can be a CSS query selector,
+a DOM element, or another Plugin. If `target` is a Plugin, the source (current)
+plugin will register with the target plugin, and the latter can decide how and
+where to render the source plugin.
 
 This method can be overridden to support for different render engines.
 
 #### `render()`
 
-Render this plugin’s UI. Uppy uses [Preact](https://preactjs.com) as its view engine,
-so `render()` should return a Preact element. `render` is automatically called by Uppy on each state change.
+Render this plugin’s UI. Uppy uses [Preact](https://preactjs.com) as its view
+engine, so `render()` should return a Preact element. `render` is automatically
+called by Uppy on each state change.
 
 #### `onMount()`
 
@@ -112,34 +118,39 @@ Called after Preact has rendered the components of the plugin.
 
 #### `update(state)`
 
-Called on each state update.
-You will rarely need to use this, unless if you want to build a UI plugin using something other than Preact.
+Called on each state update. You will rarely need to use this, unless if you
+want to build a UI plugin using something other than Preact.
 
 #### `onUnmount()`
 
-Called after the elements have been removed from the DOM. Can be used to do some clean up or other side-effects.
+Called after the elements have been removed from the DOM. Can be used to do some
+clean up or other side-effects.
 
 ## Upload Hooks
 
-When creating an upload, Uppy runs files through an upload pipeline.
-The pipeline consists of three parts, each of which can be hooked into: Preprocessing, Uploading, and Postprocessing.
-Preprocessors can be used to configure uploader plugins, encrypt files, resize images, etc., before uploading them.
-Uploaders do the actual uploading work, such as creating an XMLHttpRequest object and sending the file.
-Postprocessors do their work after files have been uploaded completely.
-This could be anything from waiting for a file to propagate across a CDN,
-to sending another request to relate some metadata to the file.
+When creating an upload, Uppy runs files through an upload pipeline. The
+pipeline consists of three parts, each of which can be hooked into:
+Preprocessing, Uploading, and Postprocessing. Preprocessors can be used to
+configure uploader plugins, encrypt files, resize images, etc., before uploading
+them. Uploaders do the actual uploading work, such as creating an XMLHttpRequest
+object and sending the file. Postprocessors do their work after files have been
+uploaded completely. This could be anything from waiting for a file to propagate
+across a CDN, to sending another request to relate some metadata to the file.
 
-Each hook is a function that receives an array containing the file IDs that are being uploaded,
-and returns a Promise to signal completion.
-Hooks are added and removed through `Uppy` methods: [`addPreProcessor`](/docs/uppy-core#addpreprocessorfn),
-[`addUploader`](/docs/uppy-core#adduploaderfn), [`addPostProcessor`](/docs/uppy-core#addpostprocessorfn),
-and their [`remove*`](/docs/uppy-core#removepreprocessorremoveuploaderremovepostprocessorfn) counterparts.
-Normally, hooks should be added during the plugin `install()` method, and removed during the `uninstall()` method.
+Each hook is a function that receives an array containing the file IDs that are
+being uploaded, and returns a Promise to signal completion. Hooks are added and
+removed through `Uppy` methods:
+[`addPreProcessor`](/docs/uppy-core#addpreprocessorfn),
+[`addUploader`](/docs/uppy-core#adduploaderfn),
+[`addPostProcessor`](/docs/uppy-core#addpostprocessorfn), and their
+[`remove*`](/docs/uppy-core#removepreprocessorremoveuploaderremovepostprocessorfn)
+counterparts. Normally, hooks should be added during the plugin `install()`
+method, and removed during the `uninstall()` method.
 
 Additionally, upload hooks can fire events to signal progress.
 
-When adding hooks, make sure to bind the hook `fn` beforehand!
-Otherwise, it will be impossible to remove. For example:
+When adding hooks, make sure to bind the hook `fn` beforehand! Otherwise, it
+will be impossible to remove. For example:
 
 ```js
 class MyPlugin extends BasePlugin {
@@ -194,18 +205,18 @@ class MyPlugin extends UIPlugin {
 ## Progress events
 
 Progress events can be fired for individual files to show feedback to the user.
-For upload progress events, only emitting how many bytes are expected and how many have been uploaded is enough.
-Uppy will handle calculating progress percentages, upload speed, etc.
+For upload progress events, only emitting how many bytes are expected and how
+many have been uploaded is enough. Uppy will handle calculating progress
+percentages, upload speed, etc.
 
-Preprocessing and postprocessing progress events are plugin-dependent and can refer to anything,
-so Uppy doesn’t try to be smart about them.
-Processing progress events can be of two types: determinate or indeterminate.
-Some processing does not have meaningful progress beyond “not done” and “done”.
-For example, sending a request to initialize a server-side resource that will serve as the upload destination.
-In those situations, indeterminate progress is suitable.
-Other processing does have meaningful progress.
-For example, encrypting a large file.
-In those situations, determinate progress is suitable.
+Preprocessing and postprocessing progress events are plugin-dependent and can
+refer to anything, so Uppy doesn’t try to be smart about them. Processing
+progress events can be of two types: determinate or indeterminate. Some
+processing does not have meaningful progress beyond “not done” and “done”. For
+example, sending a request to initialize a server-side resource that will serve
+as the upload destination. In those situations, indeterminate progress is
+suitable. Other processing does have meaningful progress. For example,
+encrypting a large file. In those situations, determinate progress is suitable.
 
 Here are the relevant events:
 
@@ -215,10 +226,13 @@ Here are the relevant events:
 
 ## JSX
 
-Since Uppy uses Preact and not React, the default Babel configuration for JSX elements does not work.
-You have to import the Preact `h` function and tell Babel to use it by adding a `/** @jsx h */` comment at the top of the file.
+Since Uppy uses Preact and not React, the default Babel configuration for JSX
+elements does not work. You have to import the Preact `h` function and tell
+Babel to use it by adding a `/** @jsx h */` comment at the top of the file.
 
-See the Preact [Getting Started Guide](https://preactjs.com/guide/getting-started) for more on Babel and JSX.
+See the Preact
+[Getting Started Guide](https://preactjs.com/guide/getting-started) for more on
+Babel and JSX.
 
 <!-- eslint-disable jsdoc/check-tag-names -->
 
@@ -238,8 +252,8 @@ class NumFiles extends UIPlugin {
 
 ## Locales
 
-For any user facing language that you use while writing your Plugin,
-please provide them as strings in the `defaultLocale` property like so:
+For any user facing language that you use while writing your Plugin, please
+provide them as strings in the `defaultLocale` property like so:
 
 ```js
 this.defaultLocale = {
@@ -254,12 +268,18 @@ this.defaultLocale = {
 };
 ```
 
-This allows them to be overridden by Locale Packs,
-or directly when users pass `locale: { strings: youCanOnlyUploadFileTypes: 'Something else completely about %{types}'} }`. For this to work, it’s also required that you call `this.i18nInit()` in the plugin constructor.
+This allows them to be overridden by Locale Packs, or directly when users pass
+`locale: { strings: youCanOnlyUploadFileTypes: 'Something else completely about %{types}'} }`.
+For this to work, it’s also required that you call `this.i18nInit()` in the
+plugin constructor.
 
 ## Example of a custom plugin
 
-Below is a full example of a [small plugin](https://github.com/arturi/uppy-plugin-image-compressor) that compresses images before uploading them. You can replace `compressorjs` method with any other work you need to do. This works especially well for async stuff, like calling an external API.
+Below is a full example of a
+[small plugin](https://github.com/arturi/uppy-plugin-image-compressor) that
+compresses images before uploading them. You can replace `compressorjs` method
+with any other work you need to do. This works especially well for async stuff,
+like calling an external API.
 
 <!-- eslint-disable consistent-return -->
 

--- a/docs/guides/choosing-uploader.md
+++ b/docs/guides/choosing-uploader.md
@@ -4,71 +4,89 @@ sidebar_position: 1
 
 # Choosing the uploader you need
 
-Versatile, reliable uploading is at the heart of Uppy. It has many configurable plugins to suit your needs.
-In this guide we will explain the different plugins, their strategies, and when to use them based on use cases.
+Versatile, reliable uploading is at the heart of Uppy. It has many configurable
+plugins to suit your needs. In this guide we will explain the different plugins,
+their strategies, and when to use them based on use cases.
 
 ## Use cases
 
 ### I want worry-free, plug-and-play uploads with Transloadit services
 
-Transloadit’s strength is versatility.
-By doing video, audio, images, documents, and more,
-you only need one vendor for [all your file processing needs][transloadit-services].
-The [`@uppy/transloadit`][] plugin directly uploads to Transloadit
-so you only have to worry about creating a [template][transloadit-concepts].
-It uses [Tus](#i-want-reliable-resumable-uploads) under the hood so you don’t have to
+Transloadit’s strength is versatility. By doing video, audio, images, documents,
+and more, you only need one vendor for [all your file processing
+needs][transloadit-services]. The [`@uppy/transloadit`][] plugin directly
+uploads to Transloadit so you only have to worry about creating a
+[template][transloadit-concepts]. It uses
+[Tus](#i-want-reliable-resumable-uploads) under the hood so you don’t have to
 sacrifice reliable, resumable uploads for convenience.
 
-You should use [`@uppy/transloadit`][] if you don’t want to host your own server,
-(optionally) need file processing, and store it in the service (such as S3 or GCS) of your liking.
-All with minimal effort.
+You should use [`@uppy/transloadit`][] if you don’t want to host your own
+server, (optionally) need file processing, and store it in the service (such as
+S3 or GCS) of your liking. All with minimal effort.
 
 ### I want reliable, resumable uploads
 
-[Tus][tus] is a new open protocol for resumable uploads built on HTTP.
-This means accidentally closing your tab or losing connection let’s you continue, for instance, your 10GB upload
-instead of starting all over.
+[Tus][tus] is a new open protocol for resumable uploads built on HTTP. This
+means accidentally closing your tab or losing connection let’s you continue, for
+instance, your 10GB upload instead of starting all over.
 
-Tus supports any language, any platform, and any network.
-It requires a client and server integration to work.
-You can checkout the client and server [implementations][tus-implementations] to find the server in your preferred language.
-You can store files on the Tus server itself, but you can also use service integrations (such as S3) to store files externally.
+Tus supports any language, any platform, and any network. It requires a client
+and server integration to work. You can checkout the client and server
+[implementations][tus-implementations] to find the server in your preferred
+language. You can store files on the Tus server itself, but you can also use
+service integrations (such as S3) to store files externally.
 
-If you want reliable, resumable uploads: use [`@uppy/tus`][] to connect to your Tus server in a few lines of code.
+If you want reliable, resumable uploads: use [`@uppy/tus`][] to connect to your
+Tus server in a few lines of code.
 
 :::tip
-If you plan to let people upload _a lot_ of files, [`@uppy/tus`][] has exponential backoff built-in.
-Meaning if your server (or proxy) returns HTTP 429 because it’s being overloaded, [`@uppy/tus`][] will
-find the ideal sweet spot to keep uploading without overloading.
+
+If you plan to let people upload _a lot_ of files, [`@uppy/tus`][] has
+exponential backoff built-in. Meaning if your server (or proxy) returns HTTP 429
+because it’s being overloaded, [`@uppy/tus`][] will find the ideal sweet spot to
+keep uploading without overloading.
+
 :::
 
 ### I want to upload to AWS S3 (or S3-compatible storage) directly
 
-When you prefer a _client-to-storage_ over a _client-to-server-to-storage_ (such as [Transloadit](/docs/upload-strategies/transloadit) or [Tus](/docs/upload-strategies/tus)) setup.
-This may in some cases be preferable, for instance, to reduce costs or the complexity of running a server and load balancer with [Tus](/docs/upload-strategies/tus).
+When you prefer a _client-to-storage_ over a _client-to-server-to-storage_ (such
+as [Transloadit](/docs/upload-strategies/transloadit) or
+[Tus](/docs/upload-strategies/tus)) setup. This may in some cases be preferable,
+for instance, to reduce costs or the complexity of running a server and load
+balancer with [Tus](/docs/upload-strategies/tus).
 
-Uppy has two plugins to make this happen [`@uppy/aws-s3`][] and [`@uppy/aws-s3-multipart`][].
+Uppy has two plugins to make this happen [`@uppy/aws-s3`][] and
+[`@uppy/aws-s3-multipart`][].
 
 #### Which one should I pick?
 
-If your users are planning to mostly upload small files and/or a lot of files, it’s better to use [`@uppy/aws-s3`][].
+If your users are planning to mostly upload small files and/or a lot of files,
+it’s better to use [`@uppy/aws-s3`][].
 
-[`@uppy/aws-s3-multipart`][] is valuable for larger files (100&nbsp;MB+) as it uploads a single object as a set of parts.
-This has certain benefits, such as improved throughput (uploading parts in parallel) and quick recovery from network issues (only the failed parts need to be retried).
-The downside is request overhead, as it needs to do creation, signing, and completion requests besides the upload requests.
-For example, if you are uploading files that are only a couple kilobytes with a 100ms roundtrip latency,
-you are spending 400ms on overhead and only a few milliseconds on uploading.
+[`@uppy/aws-s3-multipart`][] is valuable for larger files (100&nbsp;MB+) as it
+uploads a single object as a set of parts. This has certain benefits, such as
+improved throughput (uploading parts in parallel) and quick recovery from
+network issues (only the failed parts need to be retried). The downside is
+request overhead, as it needs to do creation, signing, and completion requests
+besides the upload requests. For example, if you are uploading files that are
+only a couple kilobytes with a 100ms roundtrip latency, you are spending 400ms
+on overhead and only a few milliseconds on uploading.
 
-If you are uploading large files (100&nbsp;MB+), we recommend [`@uppy/aws-s3-multipart`][], otherwise [`@uppy/aws-s3`][].
+If you are uploading large files (100&nbsp;MB+), we recommend
+[`@uppy/aws-s3-multipart`][], otherwise [`@uppy/aws-s3`][].
 
 :::info
+
 You can also save files in S3 with the [`/s3/store`][s3-robot] robot while still
 using the powers of Transloadit services.
+
 :::
 
 ### I want to send regular HTTP uploads to my own server
 
-[`@uppy/xhr-upload`][] handles classic HTML multipart form uploads as well as uploads using the HTTP `PUT` method.
+[`@uppy/xhr-upload`][] handles classic HTML multipart form uploads as well as
+uploads using the HTTP `PUT` method.
 
 [s3-robot]: https://transloadit.com/services/file-exporting/s3-store/
 [transloadit-services]: https://transloadit.com/services/

--- a/docs/guides/migrate-2.0.md
+++ b/docs/guides/migrate-2.0.md
@@ -6,7 +6,11 @@ sidebar_position: 5
 
 ### New bundle requires manual polyfilling
 
-With 2.0, following in the footsteps of Microsoft, we are dropping support for IE11. As a result, we are able to remove all built-in polyfills, and the new bundle size is **25% smaller**! If you want your app to still support older browsers (such as IE11), you may need to add the following polyfills to your bundle:
+With 2.0, following in the footsteps of Microsoft, we are dropping support for
+IE11. As a result, we are able to remove all built-in polyfills, and the new
+bundle size is **25% smaller**! If you want your app to still support older
+browsers (such as IE11), you may need to add the following polyfills to your
+bundle:
 
 - [abortcontroller-polyfill](https://github.com/mo/abortcontroller-polyfill)
 - [core-js](https://github.com/zloirock/core-js)
@@ -31,7 +35,10 @@ export { default } from '@uppy/core';
 export * from '@uppy/core';
 ```
 
-If you’re using Uppy from a CDN, we now provide two bundles: one for up-to-date browsers that do not include polyfills and use modern syntax, and one for legacy browsers. When migrating, be mindful about the types of browsers you want to support:
+If you’re using Uppy from a CDN, we now provide two bundles: one for up-to-date
+browsers that do not include polyfills and use modern syntax, and one for legacy
+browsers. When migrating, be mindful about the types of browsers you want to
+support:
 
 ```html
 <!-- Modern browsers (recommended) -->
@@ -47,13 +54,19 @@ If you’re using Uppy from a CDN, we now provide two bundles: one for up-to-dat
 </script>
 ```
 
-Please note that while you may be able to get 2.0 to work in IE11 this way, we do not officially support it anymore.
+Please note that while you may be able to get 2.0 to work in IE11 this way, we
+do not officially support it anymore.
 
 ### Use `BasePlugin` or `UIPlugin` instead of `Plugin`
 
-[`@uppy/core`][core] used to provide a `Plugin` class for creating plugins. This was used for any official plugin, but also for users who want to create their own custom plugin. But, `Plugin` always came bundled with Preact, even if the plugin itself didn’t add any UI elements.
+[`@uppy/core`][core] used to provide a `Plugin` class for creating plugins. This
+was used for any official plugin, but also for users who want to create their
+own custom plugin. But, `Plugin` always came bundled with Preact, even if the
+plugin itself didn’t add any UI elements.
 
-`Plugin` has been replaced with `BasePlugin` and `UIPlugin`. `BasePlugin` is the minimum you need to create a plugin and `UIPlugin` adds Preact for rendering user interfaces.
+`Plugin` has been replaced with `BasePlugin` and `UIPlugin`. `BasePlugin` is the
+minimum you need to create a plugin and `UIPlugin` adds Preact for rendering
+user interfaces.
 
 You can import them from [`@uppy/core`][core]:
 
@@ -61,7 +74,9 @@ You can import them from [`@uppy/core`][core]:
 import { BasePlugin, UIPlugin } from '@uppy/core';
 ```
 
-**Note:** some bundlers will include `UIPlugin` (and thus Preact) if you import from `@uppy/core`. To make sure this does not happen, you can import `Uppy` and `BasePlugin` directly:
+**Note:** some bundlers will include `UIPlugin` (and thus Preact) if you import
+from `@uppy/core`. To make sure this does not happen, you can import `Uppy` and
+`BasePlugin` directly:
 
 ```js
 import Uppy from '@uppy/core/lib/Uppy.js';
@@ -70,11 +85,15 @@ import BasePlugin from '@uppy/core/lib/BasePlugin.js';
 
 ### Use the latest Preact for your Uppy plugins
 
-Official plugins have already been upgraded. If you are using any custom plugins, upgrade Preact to the latest version. At the time of writing this is `10.5.13`.
+Official plugins have already been upgraded. If you are using any custom
+plugins, upgrade Preact to the latest version. At the time of writing this is
+`10.5.13`.
 
 ### Set plugin titles from locales
 
-Titles for plugins used to be set with the `title` property in the plugin options, but all other strings are set in `locale`. This has now been aligned. You should set your plugin title from the `locale` property.
+Titles for plugins used to be set with the `title` property in the plugin
+options, but all other strings are set in `locale`. This has now been aligned.
+You should set your plugin title from the `locale` property.
 
 Before
 
@@ -102,7 +121,8 @@ uppy.use(Webcam, {
 
 ### Initialize Uppy with the `new` keyword
 
-The default export `Uppy` is no longer callable as a function. This means you construct the `Uppy` instance using the `new` keyword.
+The default export `Uppy` is no longer callable as a function. This means you
+construct the `Uppy` instance using the `new` keyword.
 
 ```js
 import Uppy from '@uppy/core';
@@ -114,11 +134,15 @@ const otherUppy = Uppy(); // incorrect, will throw.
 
 ### Rename `allowMultipleUploads` to `allowMultipleUploadBatches`
 
-[`allowMultipleUploadBatches`](https://uppy.io/docs/uppy/#allowMultipleUploadBatches-true) means allowing several calls to [`.upload()`](https://uppy.io/docs/uppy/#uppy-upload), in other words, a user can add more files after already having uploaded some.
+[`allowMultipleUploadBatches`](https://uppy.io/docs/uppy/#allowMultipleUploadBatches-true)
+means allowing several calls to
+[`.upload()`](https://uppy.io/docs/uppy/#uppy-upload), in other words, a user
+can add more files after already having uploaded some.
 
 <!--retext-simplify ignore multiple-->
 
-We have renamed this to be more intention revealing that this is about uploads, and not whether a user can choose multiple files for one upload.
+We have renamed this to be more intention revealing that this is about uploads,
+and not whether a user can choose multiple files for one upload.
 
 ```js
 const uppy = new Uppy({
@@ -128,7 +152,8 @@ const uppy = new Uppy({
 
 ### New default limits for [`@uppy/xhr-upload`][xhr] and [`@uppy/tus`][tus]
 
-The default limit has been changed from `0` to `5`. Setting this to `0` means no limit on concurrent uploads.
+The default limit has been changed from `0` to `5`. Setting this to `0` means no
+limit on concurrent uploads.
 
 You can change the limit on the Tus and XHR plugin options.
 
@@ -148,7 +173,9 @@ uppy.use(XHRUpload, {
 
 ### TypeScript changes
 
-Uppy used to have loose types by default and strict types as an opt-in. The default export was a function that returned the `Uppy` class, and the types came bundled with the default export (`Uppy.SomeType`).
+Uppy used to have loose types by default and strict types as an opt-in. The
+default export was a function that returned the `Uppy` class, and the types came
+bundled with the default export (`Uppy.SomeType`).
 
 ```ts
 import Uppy from '@uppy/core';
@@ -183,7 +210,10 @@ import type { PluginOptions, UIPlugin, PluginTarget } from '@uppy/core';
 
 #### Event types
 
-[`@uppy/core`][core] provides an [`.on`](/docs/uppy/#uppy-on-39-event-39-action) method to listen to [events](/docs/uppy/#Events). The types for these events were loose and allowed for invalid events to be passed, such as `uppy.on('upload-errrOOOoooOOOOOrrrr')`.
+[`@uppy/core`][core] provides an [`.on`](/docs/uppy/#uppy-on-39-event-39-action)
+method to listen to [events](/docs/uppy/#Events). The types for these events
+were loose and allowed for invalid events to be passed, such as
+`uppy.on('upload-errrOOOoooOOOOOrrrr')`.
 
 <!-- eslint-disable @typescript-eslint/no-unused-vars -->
 
@@ -214,7 +244,10 @@ uppy.on<'complete', Meta>('complete', (result) => {
 });
 ```
 
-Plugins that add their own events can merge with existing ones in `@uppy/core` with `declare module '@uppy/core' { ... }`. This is a TypeScript pattern called [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation). For instance, when using [`@uppy/dashboard`][dashboard]:
+Plugins that add their own events can merge with existing ones in `@uppy/core`
+with `declare module '@uppy/core' { ... }`. This is a TypeScript pattern called
+[module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation).
+For instance, when using [`@uppy/dashboard`][dashboard]:
 
 <!-- eslint-disable @typescript-eslint/no-unused-vars -->
 
@@ -226,25 +259,42 @@ uppy.on('dashboard:file-edit-state', (file) => {
 
 ### Changes to pre-signing URLs for [`@uppy/aws-s3-multipart`][aws-s3-multipart]
 
-See the Uppy 2.0.0 announcement post about the batch [pre-signing URLs change](https://uppy.io/blog/2021/08/2.0/#Batch-pre-signing-URLs-for-AWS-S3-Multipart).
+See the Uppy 2.0.0 announcement post about the batch
+[pre-signing URLs change](https://uppy.io/blog/2021/08/2.0/#Batch-pre-signing-URLs-for-AWS-S3-Multipart).
 
-`prepareUploadPart` has been renamed to [`prepareUploadParts`](https://uppy.io/docs/aws-s3-multipart/#prepareUploadParts-file-partData) (plural). See the documentation link on how to use this function.
+`prepareUploadPart` has been renamed to
+[`prepareUploadParts`](https://uppy.io/docs/aws-s3-multipart/#prepareUploadParts-file-partData)
+(plural). See the documentation link on how to use this function.
 
 ### Removed the `.run` method from [`@uppy/core`][core]
 
-The `.run` method on the `Uppy` instance has been removed. This method was already obsolete and only logged a warning. As of this major version, it no longer exists.
+The `.run` method on the `Uppy` instance has been removed. This method was
+already obsolete and only logged a warning. As of this major version, it no
+longer exists.
 
 ### Removed `resume` and `removeFingerprintOnSuccess` options from [`@uppy/tus`][tus]
 
-Tus will now by default try to resume uploads if the upload has been started in the past.
+Tus will now by default try to resume uploads if the upload has been started in
+the past.
 
-This also means tus will store some data in localStorage for each upload, which will automatically be removed on success. Making `removeFingerprintOnSuccess` obsolete too.
+This also means tus will store some data in localStorage for each upload, which
+will automatically be removed on success. Making `removeFingerprintOnSuccess`
+obsolete too.
 
 ### That’s it!
 
-Uppy 1.0 will continue to receive bug fixes for three more months (until <time datetime="2021-12-01">1 December 2021</time>), security fixes for one more year (until <time datetime="2022-09-01">1 September 2022</time>), but no more new features after today. Exceptions are unlikely, but _can_ be made – to accommodate those with commercial support contracts, for example.
+Uppy 1.0 will continue to receive bug fixes for three more months (until
+<time datetime="2021-12-01">1 December 2021</time>), security fixes for one more
+year (until <time datetime="2022-09-01">1 September 2022</time>), but no more
+new features after today. Exceptions are unlikely, but _can_ be made – to
+accommodate those with commercial support contracts, for example.
 
-We hope you’ll waste no time in taking Uppy 2.0 out for a walk. When you do, please let us know what you thought of it on [Reddit](https://www.reddit.com/r/javascript/comments/penbr7/uppy_file_uploader_20_smaller_and_faster_modular/), [HN](https://news.ycombinator.com/item?id=28359287), ProductHunt, or [Twitter](https://twitter.com/uppy_io/status/1432399270846603264). We’re howling at the moon to hear from you!
+We hope you’ll waste no time in taking Uppy 2.0 out for a walk. When you do,
+please let us know what you thought of it on
+[Reddit](https://www.reddit.com/r/javascript/comments/penbr7/uppy_file_uploader_20_smaller_and_faster_modular/),
+[HN](https://news.ycombinator.com/item?id=28359287), ProductHunt, or
+[Twitter](https://twitter.com/uppy_io/status/1432399270846603264). We’re howling
+at the moon to hear from you!
 
 ## Migrating Companion v1 to v2
 
@@ -254,11 +304,14 @@ Since v2, you now need to be running `node.js >= v10.20.1` to use Companion.
 
 ### ProviderOptions
 
-In v2 the `google` and `microsoft` [providerOptions](https://uppy.io/docs/companion/#Options) have been changed to `drive` and `onedrive` respectively.
+In v2 the `google` and `microsoft`
+[providerOptions](https://uppy.io/docs/companion/#Options) have been changed to
+`drive` and `onedrive` respectively.
 
 ### OAuth Redirect URIs
 
-On your Providers’ respective developer platforms, the OAuth redirect URIs that you should supply has now changed from:
+On your Providers’ respective developer platforms, the OAuth redirect URIs that
+you should supply has now changed from:
 
 `http(s)://$COMPANION_HOST_NAME/connect/$AUTH_PROVIDER/callback` in v1
 

--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -9,14 +9,18 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # Quick start
 
-Uppy is an uploader and (optionally) an user interface, tied together by the [core library][core],
-with lots of plugins to gradually add more functionality.
+Uppy is an uploader and (optionally) an user interface, tied together by the
+[core library][core], with lots of plugins to gradually add more functionality.
 
-In this quick start we will build a small yet powerful example with [@uppy/dashboard][] and [@uppy/tus][].
+In this quick start we will build a small yet powerful example with
+[@uppy/dashboard][] and [@uppy/tus][].
 
 :::tip
-You can take Uppy for a walk with the **[Stackblitz](#)** or **[CodeSandbox](#)** examples.
-Both examples can also be cloned with Git for a kickstart locally.
+
+You can take Uppy for a walk with the **[Stackblitz](#)** or
+**[CodeSandbox](#)** examples. Both examples can also be cloned with Git for a
+kickstart locally.
+
 :::
 
 <Tabs>
@@ -52,17 +56,20 @@ yarn add @uppy/core @uppy/dashboard @uppy/tus
 
 ## Next steps
 
-That’s it! You tried Uppy for the first time.
-This was a taste of what Uppy can do, its power comes from modularity and versatility.
+That’s it! You tried Uppy for the first time. This was a taste of what Uppy can
+do, its power comes from modularity and versatility.
 
 Here are some interesting things:
 
 - [Choosing the uploader you need](/docs/guides/choosing-uploader).
-- With [Companion](/docs/companion) your users will be able to select files from remote sources, such as Instagram,
-  Google Drive and Dropbox. It bypasses the client (so a 5 GB video isn’t eating into your users’ data plans)
-  and uploads to your preferred final destination.
-- Recover files from accidental refreshes or closed tabs with [Golden Retriever](/docs/golden-retriever).
-- Add [image editing](/docs/user-interfaces/elements/image-editor) to [Dashboard][@uppy/dashboard].
+- With [Companion](/docs/companion) your users will be able to select files from
+  remote sources, such as Instagram, Google Drive and Dropbox. It bypasses the
+  client (so a 5 GB video isn’t eating into your users’ data plans) and uploads
+  to your preferred final destination.
+- Recover files from accidental refreshes or closed tabs with
+  [Golden Retriever](/docs/golden-retriever).
+- Add [image editing](/docs/user-interfaces/elements/image-editor) to
+  [Dashboard][@uppy/dashboard].
 
 [core]: /docs/uppy-core
 [@uppy/dashboard]: /docs/user-interfaces/dashboard

--- a/docs/sources/companion-plugins/box.mdx
+++ b/docs/sources/companion-plugins/box.mdx
@@ -5,21 +5,28 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # Box
 
-The `@uppy/box` plugin lets users import files from their [Box](https://www.box.com/en-nl/home) account.
+The `@uppy/box` plugin lets users import files from their
+[Box](https://www.box.com/en-nl/home) account.
 
 :::tip
-[Try out the live example](/examples) or take it for a spin in [CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
+[Try out the live example](/examples) or take it for a spin in
+[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
 :::
 
 ## When should I use this?
 
-When you want to let users import files from their [Box](https://www.box.com/en-nl/home) account.
+When you want to let users import files from their
+[Box](https://www.box.com/en-nl/home) account.
 
 A [Companion](/docs/companion) instance is required for the Box plugin to work.
-Companion handles authentication with Box, downloads the files, and uploads them to the destination.
-This saves the user bandwidth, especially helpful if they are on a mobile connection.
+Companion handles authentication with Box, downloads the files, and uploads them
+to the destination. This saves the user bandwidth, especially helpful if they
+are on a mobile connection.
 
-You can self-host Companion or get a hosted version with any [Transloadit plan](https://transloadit.com/pricing/).
+You can self-host Companion or get a hosted version with any
+[Transloadit plan](https://transloadit.com/pricing/).
 
 <Tabs>
   <TabItem value="npm" label="NPM" default>
@@ -73,14 +80,18 @@ new Uppy().use(Dashboard, { inline: true, target: '#dashboard' }).use(Box, {
 
 ### Use in Companion
 
-You can create a Box App on the [Box Developers site](https://app.box.com/developers/console).
+You can create a Box App on the
+[Box Developers site](https://app.box.com/developers/console).
 
 Things to note:
 
-- Choose `Custom App` and select the `Standard OAuth 2.0 (User Authentication)` app type.
-- You must enable full write access, or you will get [403 when downloading files](https://support.box.com/hc/en-us/community/posts/360049195613-403-error-while-file-download-API-Call)
+- Choose `Custom App` and select the `Standard OAuth 2.0 (User Authentication)`
+  app type.
+- You must enable full write access, or you will get
+  [403 when downloading files](https://support.box.com/hc/en-us/community/posts/360049195613-403-error-while-file-download-API-Call)
 
-You’ll be redirected to the app page. This page lists the client ID (app key) and client secret (app secret), which you should use to configure Companion.
+You’ll be redirected to the app page. This page lists the client ID (app key)
+and client secret (app secret), which you should use to configure Companion.
 
 The app page has a `"Redirect URIs"` field. Here, add:
 
@@ -88,10 +99,12 @@ The app page has a `"Redirect URIs"` field. Here, add:
 https://$YOUR_COMPANION_HOST_NAME/box/redirect
 ```
 
-You can only use the integration with your own account initially.
-Make sure to apply for production status on the app page before you publish your app, or your users will not be able to sign in!
+You can only use the integration with your own account initially. Make sure to
+apply for production status on the app page before you publish your app, or your
+users will not be able to sign in!
 
-Configure the Box key and secret. With the standalone Companion server, specify environment variables:
+Configure the Box key and secret. With the standalone Companion server, specify
+environment variables:
 
 ```shell
 export COMPANION_BOX_KEY="Box API key"
@@ -121,11 +134,13 @@ A unique identifier for this plugin (`string`, default: `'Box'`).
 
 #### `title`
 
-Title / name shown in the UI, such as Dashboard tabs (`string`, default: `'Box'`).
+Title / name shown in the UI, such as Dashboard tabs (`string`, default:
+`'Box'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into
+(`string` or `Element`, default: `null`).
 
 #### `companionUrl`
 
@@ -133,18 +148,23 @@ URL to a [Companion](/docs/companion) instance (`string`, default: `null`).
 
 #### `companionHeaders`
 
-Custom headers that should be sent along to [Companion](/docs/companion) on every request (`Object`, default: `{}`).
+Custom headers that should be sent along to [Companion](/docs/companion) on
+every request (`Object`, default: `{}`).
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `RegExp` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted
+(`string` or `RegExp` or `Array`, default: `companionUrl`).
 
-This value can be a `string`, a `RegExp` pattern, or an `Array` of both.
-This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
+This value can be a `string`, a `RegExp` pattern, or an `Array` of both. This is
+useful when you have your [Companion](/docs/companion) running on several hosts.
+Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`
 
-This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`string`, default: `'same-origin'`).
+This option correlates to the
+[RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials)
+(`string`, default: `'same-origin'`).
 
 This tells the plugin whether to send cookies to [Companion](/docs/companion).
 

--- a/docs/sources/companion-plugins/dropbox.mdx
+++ b/docs/sources/companion-plugins/dropbox.mdx
@@ -5,21 +5,28 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # Dropbox
 
-The `@uppy/dropbox` plugin lets users import files from their [Dropbox](https://www.dropbox.com) account.
+The `@uppy/dropbox` plugin lets users import files from their
+[Dropbox](https://www.dropbox.com) account.
 
 :::tip
-[Try out the live example](/examples) or take it for a spin in [CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
+[Try out the live example](/examples) or take it for a spin in
+[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
 :::
 
 ## When should I use this?
 
-When you want to let users import files from their [Dropbox](https://www.dropbox.com) account.
+When you want to let users import files from their
+[Dropbox](https://www.dropbox.com) account.
 
-A [Companion](/docs/companion) instance is required for the Dropbox plugin to work.
-Companion handles authentication with Dropbox, downloads the files, and uploads them to the destination.
-This saves the user bandwidth, especially helpful if they are on a mobile connection.
+A [Companion](/docs/companion) instance is required for the Dropbox plugin to
+work. Companion handles authentication with Dropbox, downloads the files, and
+uploads them to the destination. This saves the user bandwidth, especially
+helpful if they are on a mobile connection.
 
-You can self-host Companion or get a hosted version with any [Transloadit plan](https://transloadit.com/pricing/).
+You can self-host Companion or get a hosted version with any
+[Transloadit plan](https://transloadit.com/pricing/).
 
 <Tabs>
   <TabItem value="npm" label="NPM" default>
@@ -73,14 +80,17 @@ new Uppy().use(Dashboard, { inline: true, target: '#dashboard' }).use(Dropbox, {
 
 ### Use in Companion
 
-You can create a Dropbox App on the [Dropbox Developers site](https://www.dropbox.com/developers/apps/create).
+You can create a Dropbox App on the
+[Dropbox Developers site](https://www.dropbox.com/developers/apps/create).
 
 Things to note:
 
 - Choose the “Dropbox API”, not the business variant.
-- Typically you’ll want “Full Dropbox” access, unless you are absolutely certain that you need the other one.
+- Typically you’ll want “Full Dropbox” access, unless you are absolutely certain
+  that you need the other one.
 
-You’ll be redirected to the app page. This page lists the app key and app secret, which you should use to configure Companion as shown above.
+You’ll be redirected to the app page. This page lists the app key and app
+secret, which you should use to configure Companion as shown above.
 
 The app page has a “Redirect URIs” field. Here, add:
 
@@ -88,10 +98,12 @@ The app page has a “Redirect URIs” field. Here, add:
 https://$YOUR_COMPANION_HOST_NAME/dropbox/redirect
 ```
 
-You can only use the integration with your own account initially.
-Make sure to apply for production status on the app page before you publish your app, or your users will not be able to sign in!
+You can only use the integration with your own account initially. Make sure to
+apply for production status on the app page before you publish your app, or your
+users will not be able to sign in!
 
-Configure the Dropbox key and secret. With the standalone Companion server, specify environment variables:
+Configure the Dropbox key and secret. With the standalone Companion server,
+specify environment variables:
 
 ```shell
 export COMPANION_DROPBOX_KEY="Dropbox API key"
@@ -121,11 +133,13 @@ A unique identifier for this plugin (`string`, default: `'Dropbox'`).
 
 #### `title`
 
-Title / name shown in the UI, such as Dashboard tabs (`string`, default: `'Dropbox'`).
+Title / name shown in the UI, such as Dashboard tabs (`string`, default:
+`'Dropbox'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into
+(`string` or `Element`, default: `null`).
 
 #### `companionUrl`
 
@@ -133,18 +147,23 @@ URL to a [Companion](/docs/companion) instance (`string`, default: `null`).
 
 #### `companionHeaders`
 
-Custom headers that should be sent along to [Companion](/docs/companion) on every request (`Object`, default: `{}`).
+Custom headers that should be sent along to [Companion](/docs/companion) on
+every request (`Object`, default: `{}`).
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `RegExp` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted
+(`string` or `RegExp` or `Array`, default: `companionUrl`).
 
-This value can be a `string`, a `RegExp` pattern, or an `Array` of both.
-This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
+This value can be a `string`, a `RegExp` pattern, or an `Array` of both. This is
+useful when you have your [Companion](/docs/companion) running on several hosts.
+Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`
 
-This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`string`, default: `'same-origin'`).
+This option correlates to the
+[RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials)
+(`string`, default: `'same-origin'`).
 
 This tells the plugin whether to send cookies to [Companion](/docs/companion).
 

--- a/docs/sources/companion-plugins/facebook.mdx
+++ b/docs/sources/companion-plugins/facebook.mdx
@@ -5,21 +5,28 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # Facebook
 
-The `@uppy/facebook` plugin lets users import files from their [Facebook](https://www.facebook.com) account.
+The `@uppy/facebook` plugin lets users import files from their
+[Facebook](https://www.facebook.com) account.
 
 :::tip
-[Try out the live example](/examples) or take it for a spin in [CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
+[Try out the live example](/examples) or take it for a spin in
+[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
 :::
 
 ## When should I use this?
 
-When you want to let users import files from their [Facebook](https://www.facebook.com) account.
+When you want to let users import files from their
+[Facebook](https://www.facebook.com) account.
 
-A [Companion](/docs/companion) instance is required for the Facebook plugin to work.
-Companion handles authentication with Facebook, downloads the files, and uploads them to the destination.
-This saves the user bandwidth, especially helpful if they are on a mobile connection.
+A [Companion](/docs/companion) instance is required for the Facebook plugin to
+work. Companion handles authentication with Facebook, downloads the files, and
+uploads them to the destination. This saves the user bandwidth, especially
+helpful if they are on a mobile connection.
 
-You can self-host Companion or get a hosted version with any [Transloadit plan](https://transloadit.com/pricing/).
+You can self-host Companion or get a hosted version with any
+[Transloadit plan](https://transloadit.com/pricing/).
 
 <Tabs>
   <TabItem value="npm" label="NPM" default>
@@ -75,7 +82,8 @@ new Uppy()
 
 ### Use in Companion
 
-You can create a Facebook App on the [Facebook Developers site](https://developers.facebook.com/).
+You can create a Facebook App on the
+[Facebook Developers site](https://developers.facebook.com/).
 
 The app page has a “Redirect URIs” field. Here, add:
 
@@ -83,12 +91,18 @@ The app page has a “Redirect URIs” field. Here, add:
 https://$YOUR_COMPANION_HOST_NAME/facebook/redirect
 ```
 
-You can only use the integration with your own account initially.
-Make sure to apply for production status on the app page before you publish your app, or your users will not be able to sign in!
+You can only use the integration with your own account initially. Make sure to
+apply for production status on the app page before you publish your app, or your
+users will not be able to sign in!
 
-You need to set up OAuth in your Facebook app for Companion to be able to connect to users’ Facebook accounts. You have to enable “Advanced Access” for the `user_photos` permission. A precondition of that is “Business Verification” which involves setting up a Meta Business Account and submitting documents to prove business ownership.
+You need to set up OAuth in your Facebook app for Companion to be able to
+connect to users’ Facebook accounts. You have to enable “Advanced Access” for
+the `user_photos` permission. A precondition of that is “Business Verification”
+which involves setting up a Meta Business Account and submitting documents to
+prove business ownership.
 
-Configure the Facebook key and secret. With the standalone Companion server, specify environment variables:
+Configure the Facebook key and secret. With the standalone Companion server,
+specify environment variables:
 
 ```shell
 export COMPANION_FACEBOOK_KEY="Facebook API key"
@@ -118,11 +132,13 @@ A unique identifier for this plugin (`string`, default: `'Facebook'`).
 
 #### `title`
 
-Title / name shown in the UI, such as Dashboard tabs (`string`, default: `'Facebook'`).
+Title / name shown in the UI, such as Dashboard tabs (`string`, default:
+`'Facebook'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into
+(`string` or `Element`, default: `null`).
 
 #### `companionUrl`
 
@@ -130,18 +146,23 @@ URL to a [Companion](/docs/companion) instance (`string`, default: `null`).
 
 #### `companionHeaders`
 
-Custom headers that should be sent along to [Companion](/docs/companion) on every request (`Object`, default: `{}`).
+Custom headers that should be sent along to [Companion](/docs/companion) on
+every request (`Object`, default: `{}`).
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `RegExp` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted
+(`string` or `RegExp` or `Array`, default: `companionUrl`).
 
-This value can be a `string`, a `RegExp` pattern, or an `Array` of both.
-This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
+This value can be a `string`, a `RegExp` pattern, or an `Array` of both. This is
+useful when you have your [Companion](/docs/companion) running on several hosts.
+Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`
 
-This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`string`, default: `'same-origin'`).
+This option correlates to the
+[RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials)
+(`string`, default: `'same-origin'`).
 
 This tells the plugin whether to send cookies to [Companion](/docs/companion).
 

--- a/docs/sources/companion-plugins/google-drive.mdx
+++ b/docs/sources/companion-plugins/google-drive.mdx
@@ -5,21 +5,28 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # Google Drive
 
-The `@uppy/google-drive` plugin lets users import files from their [Google Drive](https://www.drive.google.com) account.
+The `@uppy/google-drive` plugin lets users import files from their
+[Google Drive](https://www.drive.google.com) account.
 
 :::tip
-[Try out the live example](/examples) or take it for a spin in [CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
+[Try out the live example](/examples) or take it for a spin in
+[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
 :::
 
 ## When should I use this?
 
-When you want to let users import files from their [Google Drive](https://www.drive.google.com) account.
+When you want to let users import files from their
+[Google Drive](https://www.drive.google.com) account.
 
-A [Companion](/docs/companion) instance is required for the Google Drive plugin to work.
-Companion handles authentication with Google Drive, downloads the files, and uploads them to the destination.
-This saves the user bandwidth, especially helpful if they are on a mobile connection.
+A [Companion](/docs/companion) instance is required for the Google Drive plugin
+to work. Companion handles authentication with Google Drive, downloads the
+files, and uploads them to the destination. This saves the user bandwidth,
+especially helpful if they are on a mobile connection.
 
-You can self-host Companion or get a hosted version with any [Transloadit plan](https://transloadit.com/pricing/).
+You can self-host Companion or get a hosted version with any
+[Transloadit plan](https://transloadit.com/pricing/).
 
 <Tabs>
   <TabItem value="npm" label="NPM" default>
@@ -75,18 +82,21 @@ new Uppy()
 
 ### Use in Companion
 
-To sign up for API keys, go to the [Google Developer Console](https://console.developers.google.com/).
+To sign up for API keys, go to the
+[Google Developer Console](https://console.developers.google.com/).
 
 Create a project for your app if you don’t have one yet.
 
-- On the project’s dashboard, [enable the Google Drive API](https://developers.google.com/drive/api/v3/enable-drive-api).
-- [Set up OAuth authorization](https://developers.google.com/drive/api/v3/about-auth). Use this for an authorized redirect URI:
+- On the project’s dashboard,
+  [enable the Google Drive API](https://developers.google.com/drive/api/v3/enable-drive-api).
+- [Set up OAuth authorization](https://developers.google.com/drive/api/v3/about-auth).
+  Use this for an authorized redirect URI:
   https://$YOUR_COMPANION_HOST_NAME/drive/redirect
 
 Google will give you an OAuth client ID and client secret.
 
-Configure the Google Drive key and secret in Companion.
-With the standalone Companion server, specify environment variables:
+Configure the Google Drive key and secret in Companion. With the standalone
+Companion server, specify environment variables:
 
 ```shell
 export COMPANION_GOOGLE_KEY="Google Drive OAuth client ID"
@@ -116,11 +126,13 @@ A unique identifier for this plugin (`string`, default: `'GoogleDrive'`).
 
 #### `title`
 
-Title / name shown in the UI, such as Dashboard tabs (`string`, default: `'GoogleDrive'`).
+Title / name shown in the UI, such as Dashboard tabs (`string`, default:
+`'GoogleDrive'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into
+(`string` or `Element`, default: `null`).
 
 #### `companionUrl`
 
@@ -128,18 +140,23 @@ URL to a [Companion](/docs/companion) instance (`string`, default: `null`).
 
 #### `companionHeaders`
 
-Custom headers that should be sent along to [Companion](/docs/companion) on every request (`Object`, default: `{}`).
+Custom headers that should be sent along to [Companion](/docs/companion) on
+every request (`Object`, default: `{}`).
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `RegExp` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted
+(`string` or `RegExp` or `Array`, default: `companionUrl`).
 
-This value can be a `string`, a `RegExp` pattern, or an `Array` of both.
-This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
+This value can be a `string`, a `RegExp` pattern, or an `Array` of both. This is
+useful when you have your [Companion](/docs/companion) running on several hosts.
+Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`
 
-This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`string`, default: `'same-origin'`).
+This option correlates to the
+[RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials)
+(`string`, default: `'same-origin'`).
 
 This tells the plugin whether to send cookies to [Companion](/docs/companion).
 

--- a/docs/sources/companion-plugins/instagram.mdx
+++ b/docs/sources/companion-plugins/instagram.mdx
@@ -5,21 +5,28 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # Instagram
 
-The `@uppy/instagram` plugin lets users import files from their [Instagram](https://instagram.com) account.
+The `@uppy/instagram` plugin lets users import files from their
+[Instagram](https://instagram.com) account.
 
 :::tip
-[Try out the live example](/examples) or take it for a spin in [CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
+[Try out the live example](/examples) or take it for a spin in
+[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
 :::
 
 ## When should I use this?
 
-When you want to let users import files from their [Instagram](https://instagram.com) account.
+When you want to let users import files from their
+[Instagram](https://instagram.com) account.
 
-A [Companion](/docs/companion) instance is required for the Instagram plugin to work.
-Companion handles authentication with Instagram, downloads the files, and uploads them to the destination.
-This saves the user bandwidth, especially helpful if they are on a mobile connection.
+A [Companion](/docs/companion) instance is required for the Instagram plugin to
+work. Companion handles authentication with Instagram, downloads the files, and
+uploads them to the destination. This saves the user bandwidth, especially
+helpful if they are on a mobile connection.
 
-You can self-host Companion or get a hosted version with any [Transloadit plan](https://transloadit.com/pricing/).
+You can self-host Companion or get a hosted version with any
+[Transloadit plan](https://transloadit.com/pricing/).
 
 <Tabs>
   <TabItem value="npm" label="NPM" default>
@@ -75,17 +82,19 @@ new Uppy()
 
 ### Use in Companion
 
-To sign up for API keys, go to the [Instagram Platform from Meta](https://developers.facebook.com/products/instagram/).
+To sign up for API keys, go to the
+[Instagram Platform from Meta](https://developers.facebook.com/products/instagram/).
 
 Create a project for your app if you don’t have one yet.
 
 - Enable the Instagram API.
-- Use this for an authorized redirect URI: `https://$YOUR\_COMPANION\_HOST\_NAME/instagram/redirect`
+- Use this for an authorized redirect URI:
+  `https://$YOUR\_COMPANION\_HOST\_NAME/instagram/redirect`
 
 Meta will give you an OAuth client ID and client secret.
 
-Configure the Instagram key and secret in Companion.
-With the standalone Companion server, specify environment variables:
+Configure the Instagram key and secret in Companion. With the standalone
+Companion server, specify environment variables:
 
 ```shell
 export COMPANION_GOOGLE_KEY="Instagram OAuth client ID"
@@ -115,11 +124,13 @@ A unique identifier for this plugin (`string`, default: `'Instagram'`).
 
 #### `title`
 
-Title / name shown in the UI, such as Dashboard tabs (`string`, default: `'Instagram'`).
+Title / name shown in the UI, such as Dashboard tabs (`string`, default:
+`'Instagram'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into
+(`string` or `Element`, default: `null`).
 
 #### `companionUrl`
 
@@ -127,18 +138,23 @@ URL to a [Companion](/docs/companion) instance (`string`, default: `null`).
 
 #### `companionHeaders`
 
-Custom headers that should be sent along to [Companion](/docs/companion) on every request (`Object`, default: `{}`).
+Custom headers that should be sent along to [Companion](/docs/companion) on
+every request (`Object`, default: `{}`).
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `RegExp` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted
+(`string` or `RegExp` or `Array`, default: `companionUrl`).
 
-This value can be a `string`, a `RegExp` pattern, or an `Array` of both.
-This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
+This value can be a `string`, a `RegExp` pattern, or an `Array` of both. This is
+useful when you have your [Companion](/docs/companion) running on several hosts.
+Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`
 
-This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`string`, default: `'same-origin'`).
+This option correlates to the
+[RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials)
+(`string`, default: `'same-origin'`).
 
 This tells the plugin whether to send cookies to [Companion](/docs/companion).
 

--- a/docs/sources/companion-plugins/onedrive.mdx
+++ b/docs/sources/companion-plugins/onedrive.mdx
@@ -5,21 +5,28 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # OneDrive
 
-The `@uppy/onedrive` plugin lets users import files from their [OneDrive](https://onedrive.com) account.
+The `@uppy/onedrive` plugin lets users import files from their
+[OneDrive](https://onedrive.com) account.
 
 :::tip
-[Try out the live example](/examples) or take it for a spin in [CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
+[Try out the live example](/examples) or take it for a spin in
+[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
 :::
 
 ## When should I use this?
 
-When you want to let users import files from their [OneDrive](https://onedrive.com) account.
+When you want to let users import files from their
+[OneDrive](https://onedrive.com) account.
 
-A [Companion](/docs/companion) instance is required for the OneDrive plugin to work.
-Companion handles authentication with OneDrive, downloads the files, and uploads them to the destination.
-This saves the user bandwidth, especially helpful if they are on a mobile connection.
+A [Companion](/docs/companion) instance is required for the OneDrive plugin to
+work. Companion handles authentication with OneDrive, downloads the files, and
+uploads them to the destination. This saves the user bandwidth, especially
+helpful if they are on a mobile connection.
 
-You can self-host Companion or get a hosted version with any [Transloadit plan](https://transloadit.com/pricing/).
+You can self-host Companion or get a hosted version with any
+[Transloadit plan](https://transloadit.com/pricing/).
 
 <Tabs>
   <TabItem value="npm" label="NPM" default>
@@ -75,17 +82,19 @@ new Uppy()
 
 ### Use in Companion
 
-To sign up for API keys, go to the [OneDrive Platform from Meta](https://developers.facebook.com/products/onedrive/).
+To sign up for API keys, go to the
+[OneDrive Platform from Meta](https://developers.facebook.com/products/onedrive/).
 
 Create a project for your app if you don’t have one yet.
 
 - Enable the OneDrive API.
-- Use this for an authorized redirect URI: `https://$YOUR\_COMPANION\_HOST\_NAME/onedrive/redirect`
+- Use this for an authorized redirect URI:
+  `https://$YOUR\_COMPANION\_HOST\_NAME/onedrive/redirect`
 
 Meta will give you an OAuth client ID and client secret.
 
-Configure the OneDrive key and secret in Companion.
-With the standalone Companion server, specify environment variables:
+Configure the OneDrive key and secret in Companion. With the standalone
+Companion server, specify environment variables:
 
 ```shell
 export COMPANION_GOOGLE_KEY="OneDrive OAuth client ID"
@@ -115,11 +124,13 @@ A unique identifier for this plugin (`string`, default: `'OneDrive'`).
 
 #### `title`
 
-Title / name shown in the UI, such as Dashboard tabs (`string`, default: `'OneDrive'`).
+Title / name shown in the UI, such as Dashboard tabs (`string`, default:
+`'OneDrive'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into
+(`string` or `Element`, default: `null`).
 
 #### `companionUrl`
 
@@ -127,18 +138,23 @@ URL to a [Companion](/docs/companion) instance (`string`, default: `null`).
 
 #### `companionHeaders`
 
-Custom headers that should be sent along to [Companion](/docs/companion) on every request (`Object`, default: `{}`).
+Custom headers that should be sent along to [Companion](/docs/companion) on
+every request (`Object`, default: `{}`).
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `RegExp` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted
+(`string` or `RegExp` or `Array`, default: `companionUrl`).
 
-This value can be a `string`, a `RegExp` pattern, or an `Array` of both.
-This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
+This value can be a `string`, a `RegExp` pattern, or an `Array` of both. This is
+useful when you have your [Companion](/docs/companion) running on several hosts.
+Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`
 
-This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`string`, default: `'same-origin'`).
+This option correlates to the
+[RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials)
+(`string`, default: `'same-origin'`).
 
 This tells the plugin whether to send cookies to [Companion](/docs/companion).
 

--- a/docs/sources/companion-plugins/unsplash.mdx
+++ b/docs/sources/companion-plugins/unsplash.mdx
@@ -5,21 +5,28 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # Unsplash
 
-The `@uppy/unsplash` plugin lets users import files from their [Unsplash](https://unsplash.com) account.
+The `@uppy/unsplash` plugin lets users import files from their
+[Unsplash](https://unsplash.com) account.
 
 :::tip
-[Try out the live example](/examples) or take it for a spin in [CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
+[Try out the live example](/examples) or take it for a spin in
+[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
 :::
 
 ## When should I use this?
 
-When you want to let users import files from their [Unsplash](https://unsplash.com) account.
+When you want to let users import files from their
+[Unsplash](https://unsplash.com) account.
 
-A [Companion](/docs/companion) instance is required for the Unsplash plugin to work.
-Companion handles authentication with Unsplash, downloads the files, and uploads them to the destination.
-This saves the user bandwidth, especially helpful if they are on a mobile connection.
+A [Companion](/docs/companion) instance is required for the Unsplash plugin to
+work. Companion handles authentication with Unsplash, downloads the files, and
+uploads them to the destination. This saves the user bandwidth, especially
+helpful if they are on a mobile connection.
 
-You can self-host Companion or get a hosted version with any [Transloadit plan](https://transloadit.com/pricing/).
+You can self-host Companion or get a hosted version with any
+[Transloadit plan](https://transloadit.com/pricing/).
 
 <Tabs>
   <TabItem value="npm" label="NPM" default>
@@ -75,10 +82,12 @@ new Uppy()
 
 ### Use in Companion
 
-You can create a Unsplash App on the [Unsplash Developers site](https://unsplash.com/developers).
-You’ll be redirected to the app page, this page lists the app key and app secret.
+You can create a Unsplash App on the
+[Unsplash Developers site](https://unsplash.com/developers). You’ll be
+redirected to the app page, this page lists the app key and app secret.
 
-Configure the Unsplash key and secret. With the standalone Companion server, specify environment variables:
+Configure the Unsplash key and secret. With the standalone Companion server,
+specify environment variables:
 
 ```shell
 export COMPANION_UNSPLASH_KEY="Unsplash API key"
@@ -108,11 +117,13 @@ A unique identifier for this plugin (`string`, default: `'Unsplash'`).
 
 #### `title`
 
-Title / name shown in the UI, such as Dashboard tabs (`string`, default: `'Unsplash'`).
+Title / name shown in the UI, such as Dashboard tabs (`string`, default:
+`'Unsplash'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into
+(`string` or `Element`, default: `null`).
 
 #### `companionUrl`
 
@@ -120,18 +131,23 @@ URL to a [Companion](/docs/companion) instance (`string`, default: `null`).
 
 #### `companionHeaders`
 
-Custom headers that should be sent along to [Companion](/docs/companion) on every request (`Object`, default: `{}`).
+Custom headers that should be sent along to [Companion](/docs/companion) on
+every request (`Object`, default: `{}`).
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `RegExp` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted
+(`string` or `RegExp` or `Array`, default: `companionUrl`).
 
-This value can be a `string`, a `RegExp` pattern, or an `Array` of both.
-This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
+This value can be a `string`, a `RegExp` pattern, or an `Array` of both. This is
+useful when you have your [Companion](/docs/companion) running on several hosts.
+Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`
 
-This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`string`, default: `'same-origin'`).
+This option correlates to the
+[RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials)
+(`string`, default: `'same-origin'`).
 
 This tells the plugin whether to send cookies to [Companion](/docs/companion).
 

--- a/docs/sources/companion-plugins/url.mdx
+++ b/docs/sources/companion-plugins/url.mdx
@@ -5,10 +5,14 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # Import from URL
 
-The `@uppy/url` plugin allows users to import files from the internet. Paste any URL and it will be added!
+The `@uppy/url` plugin allows users to import files from the internet. Paste any
+URL and it will be added!
 
 :::tip
-[Try out the live example](/examples) or take it for a spin in [CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
+[Try out the live example](/examples) or take it for a spin in
+[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
 :::
 
 ## When should I use this?
@@ -16,13 +20,19 @@ The `@uppy/url` plugin allows users to import files from the internet. Paste any
 When you want to let users import files any URL.
 
 A [Companion](/docs/companion) instance is required for the URL plugin to work.
-This saves the user bandwidth, especially helpful if they are on a mobile connection.
+This saves the user bandwidth, especially helpful if they are on a mobile
+connection.
 
-You can self-host Companion or get a hosted version with any [Transloadit plan](https://transloadit.com/pricing/).
+You can self-host Companion or get a hosted version with any
+[Transloadit plan](https://transloadit.com/pricing/).
 
 :::note
-Companion has [Server Side Request Forgery](https://owasp.org/www-community/attacks/Server_Side_Request_Forgery) (SSRF) protections build-in
-so you don’t have to worry about the security implications of arbitrary URLs.
+
+Companion has
+[Server Side Request Forgery](https://owasp.org/www-community/attacks/Server_Side_Request_Forgery)
+(SSRF) protections build-in so you don’t have to worry about the security
+implications of arbitrary URLs.
+
 :::
 
 <Tabs>
@@ -77,7 +87,8 @@ new Uppy().use(Dashboard, { inline: true, target: '#dashboard' }).use(Url, {
 
 ### Use in Companion
 
-Companion supports this plugin out-of-the-box so integration is required on this side.
+Companion supports this plugin out-of-the-box so integration is required on this
+side.
 
 ## API
 
@@ -89,11 +100,13 @@ A unique identifier for this plugin (`string`, default: `'Url'`).
 
 #### `title`
 
-Title / name shown in the UI, such as Dashboard tabs (`string`, default: `'Url'`).
+Title / name shown in the UI, such as Dashboard tabs (`string`, default:
+`'Url'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into
+(`string` or `Element`, default: `null`).
 
 #### `companionUrl`
 
@@ -101,18 +114,23 @@ URL to a [Companion](/docs/companion) instance (`string`, default: `null`).
 
 #### `companionHeaders`
 
-Custom headers that should be sent along to [Companion](/docs/companion) on every request (`Object`, default: `{}`).
+Custom headers that should be sent along to [Companion](/docs/companion) on
+every request (`Object`, default: `{}`).
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `RegExp` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted
+(`string` or `RegExp` or `Array`, default: `companionUrl`).
 
-This value can be a `string`, a `RegExp` pattern, or an `Array` of both.
-This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
+This value can be a `string`, a `RegExp` pattern, or an `Array` of both. This is
+useful when you have your [Companion](/docs/companion) running on several hosts.
+Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`
 
-This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`string`, default: `'same-origin'`).
+This option correlates to the
+[RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials)
+(`string`, default: `'same-origin'`).
 
 This tells the plugin whether to send cookies to [Companion](/docs/companion).
 

--- a/docs/sources/companion-plugins/zoom.mdx
+++ b/docs/sources/companion-plugins/zoom.mdx
@@ -5,21 +5,28 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # Zoom
 
-The `@uppy/zoom` plugin lets users import files from their [Zoom](https://zoom.com) account.
+The `@uppy/zoom` plugin lets users import files from their
+[Zoom](https://zoom.com) account.
 
 :::tip
-[Try out the live example](/examples) or take it for a spin in [CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
+[Try out the live example](/examples) or take it for a spin in
+[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
 :::
 
 ## When should I use this?
 
-When you want to let users import files from their [Zoom](https://zoom.com) account.
+When you want to let users import files from their [Zoom](https://zoom.com)
+account.
 
 A [Companion](/docs/companion) instance is required for the Zoom plugin to work.
-Companion handles authentication with Zoom, downloads the files, and uploads them to the destination.
-This saves the user bandwidth, especially helpful if they are on a mobile connection.
+Companion handles authentication with Zoom, downloads the files, and uploads
+them to the destination. This saves the user bandwidth, especially helpful if
+they are on a mobile connection.
 
-You can self-host Companion or get a hosted version with any [Transloadit plan](https://transloadit.com/pricing/).
+You can self-host Companion or get a hosted version with any
+[Transloadit plan](https://transloadit.com/pricing/).
 
 <Tabs>
   <TabItem value="npm" label="NPM" default>
@@ -73,7 +80,8 @@ new Uppy().use(Dashboard, { inline: true, target: '#dashboard' }).use(Zoom, {
 
 ### Use in Companion
 
-Configure the Zoom key and secret. With the standalone Companion server, specify environment variables:
+Configure the Zoom key and secret. With the standalone Companion server, specify
+environment variables:
 
 ```shell
 export COMPANION_ZOOM_KEY="Zoom API key"
@@ -103,11 +111,13 @@ A unique identifier for this plugin (`string`, default: `'Zoom'`).
 
 #### `title`
 
-Title / name shown in the UI, such as Dashboard tabs (`string`, default: `'Zoom'`).
+Title / name shown in the UI, such as Dashboard tabs (`string`, default:
+`'Zoom'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into
+(`string` or `Element`, default: `null`).
 
 #### `companionUrl`
 
@@ -115,18 +125,23 @@ URL to a [Companion](/docs/companion) instance (`string`, default: `null`).
 
 #### `companionHeaders`
 
-Custom headers that should be sent along to [Companion](/docs/companion) on every request (`Object`, default: `{}`).
+Custom headers that should be sent along to [Companion](/docs/companion) on
+every request (`Object`, default: `{}`).
 
 #### `companionAllowedHosts`
 
-The valid and authorised URL(s) from which OAuth responses should be accepted (`string` or `RegExp` or `Array`, default: `companionUrl`).
+The valid and authorised URL(s) from which OAuth responses should be accepted
+(`string` or `RegExp` or `Array`, default: `companionUrl`).
 
-This value can be a `string`, a `RegExp` pattern, or an `Array` of both.
-This is useful when you have your [Companion](/docs/companion) running on several hosts. Otherwise, the default value should do fine.
+This value can be a `string`, a `RegExp` pattern, or an `Array` of both. This is
+useful when you have your [Companion](/docs/companion) running on several hosts.
+Otherwise, the default value should do fine.
 
 #### `companionCookiesRule`
 
-This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`string`, default: `'same-origin'`).
+This option correlates to the
+[RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials)
+(`string`, default: `'same-origin'`).
 
 This tells the plugin whether to send cookies to [Companion](/docs/companion).
 

--- a/docs/sources/screen-capture.mdx
+++ b/docs/sources/screen-capture.mdx
@@ -9,20 +9,31 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # Screen capture
 
-The `@uppy/screen-capture` plugin can record your screen or an application and save it as a video.
+The `@uppy/screen-capture` plugin can record your screen or an application and
+save it as a video.
 
 :::tip
-[Try out the live example](/examples) or take it for a spin in [CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
+[Try out the live example](/examples) or take it for a spin in
+[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
 :::
 
 ## When should I use this?
 
-When you want users record their screen on their computer.
-This plugin only works on desktop browsers which support [`getDisplayMedia API`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia).
-If no support for the API is detected, Screen Capture won’t be installed, so you don’t have to do anything.
+When you want users record their screen on their computer. This plugin only
+works on desktop browsers which support
+[`getDisplayMedia API`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia).
+If no support for the API is detected, Screen Capture won’t be installed, so you
+don’t have to do anything.
 
 :::note
-To use the screen capture plugin in a Chromium-based browser, [your site must be served over https](https://developers.google.com/web/updates/2015/10/chrome-47-webrtc#public_service_announcements). This restriction does not apply on `localhost`, so you don’t have to jump through many hoops during development.
+
+To use the screen capture plugin in a Chromium-based browser,
+[your site must be served over https](https://developers.google.com/web/updates/2015/10/chrome-47-webrtc#public_service_announcements).
+This restriction does not apply on `localhost`, so you don’t have to jump
+through many hoops during development.
+
 :::
 
 ## Install
@@ -82,32 +93,45 @@ A unique identifier for this plugin (`string`, default: `'ScreenCapture'`).
 
 #### `title`
 
-Configures the title / name shown in the UI, for instance, on Dashboard tabs (`string`, default: `'Screen Capture'`).
+Configures the title / name shown in the UI, for instance, on Dashboard tabs
+(`string`, default: `'Screen Capture'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into
+(`string` or `Element`, default: `null`).
 
 #### `displayMediaConstraints`
 
-Options passed to [`MediaDevices.getDisplayMedia()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia) (`Object`, default: `null`).
+Options passed to
+[`MediaDevices.getDisplayMedia()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia)
+(`Object`, default: `null`).
 
-See the [`MediaTrackConstraints`](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints) for a list of options.
+See the
+[`MediaTrackConstraints`](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints)
+for a list of options.
 
 #### `userMediaConstraints`
 
-Options passed to [`MediaDevices.getUserMedia()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia) (`Object`, default: `null`).
+Options passed to
+[`MediaDevices.getUserMedia()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia)
+(`Object`, default: `null`).
 
-See the [`MediaTrackConstraints`](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints) for a list of options.
+See the
+[`MediaTrackConstraints`](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints)
+for a list of options.
 
 #### `preferredVideoMimeType`
 
-Set the preferred mime type for video recordings, for example `'video/webm'` (`string`, default: `null`).
+Set the preferred mime type for video recordings, for example `'video/webm'`
+(`string`, default: `null`).
 
-If the browser supports the given mime type, the video will be recorded in this format.
-If the browser does not support it, it will use the browser default.
+If the browser supports the given mime type, the video will be recorded in this
+format. If the browser does not support it, it will use the browser default.
 
-If no preferred video mime type is given, the ScreenCapture plugin will prefer types listed in the [`allowedFileTypes` restriction](/docs/uppy/#restrictions), if any.
+If no preferred video mime type is given, the ScreenCapture plugin will prefer
+types listed in the [`allowedFileTypes` restriction](/docs/uppy/#restrictions),
+if any.
 
 #### `locale`
 

--- a/docs/sources/webcam.mdx
+++ b/docs/sources/webcam.mdx
@@ -9,17 +9,22 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # Webcam
 
-The `@uppy/webcam` plugin lets you take photos and record videos with a built-in camera on desktop and mobile devices.
+The `@uppy/webcam` plugin lets you take photos and record videos with a built-in
+camera on desktop and mobile devices.
 
 :::tip
-[Try out the live example](/examples) or take it for a spin in [CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
+[Try out the live example](/examples) or take it for a spin in
+[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
 :::
 
 ## When should I use it?
 
-When you want your users to able to use their camera.
-This plugin is published separately but made specifically for the [Dashboard](/docs/user-interfaces/dashboard).
-You can technically use it without it, but it’s not officially supported.
+When you want your users to able to use their camera. This plugin is published
+separately but made specifically for the
+[Dashboard](/docs/user-interfaces/dashboard). You can technically use it without
+it, but it’s not officially supported.
 
 ## Install
 
@@ -55,7 +60,12 @@ yarn add @uppy/webcam
 ## Use
 
 :::note
-To use the Webcam plugin in Chrome, [your site must be served over https](https://developers.google.com/web/updates/2015/10/chrome-47-webrtc#public_service_announcements). This restriction does not apply on `localhost`, so you don’t have to jump through many hoops during development.
+
+To use the Webcam plugin in Chrome,
+[your site must be served over https](https://developers.google.com/web/updates/2015/10/chrome-47-webrtc#public_service_announcements).
+This restriction does not apply on `localhost`, so you don’t have to jump
+through many hoops during development.
+
 :::
 
 ```js {3,7,11} showLineNumbers
@@ -82,21 +92,26 @@ A unique identifier for this plugin (`string`, default: `'Webcam'`).
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into
+(`string` or `Element`, default: `null`).
 
 #### `countdown`
 
-When taking a picture: the amount of seconds to wait before actually taking a snapshot (`boolean`, default: `false`).
+When taking a picture: the amount of seconds to wait before actually taking a
+snapshot (`boolean`, default: `false`).
 
-If set to `false` or 0, the snapshot is taken right away.
-This also shows a `Smile!` message through the [Informer](/docs/informer) before the picture is taken.
+If set to `false` or 0, the snapshot is taken right away. This also shows a
+`Smile!` message through the [Informer](/docs/informer) before the picture is
+taken.
 
 #### `onBeforeSnapshot`
 
-A hook function to call before a snapshot is taken (`Function`, default: `Promise.resolve`).
+A hook function to call before a snapshot is taken (`Function`, default:
+`Promise.resolve`).
 
-The Webcam plugin will wait for the returned Promise to resolve before taking the snapshot.
-This can be used to carry out variations on the `countdown` option for example.
+The Webcam plugin will wait for the returned Promise to resolve before taking
+the snapshot. This can be used to carry out variations on the `countdown` option
+for example.
 
 #### `modes`
 
@@ -107,71 +122,99 @@ The types of recording modes to allow (`Array`, default: `[]`).
 - `audio-only` - Record an audio file with the user’s microphone.
 - `picture` - Take a picture with the webcam.
 
-By default, all modes are allowed, and the Webcam plugin will show controls for recording video as well as taking pictures.
+By default, all modes are allowed, and the Webcam plugin will show controls for
+recording video as well as taking pictures.
 
 #### `mirror`
 
-Configures whether to mirror preview image from the camera (`boolean`, default: `true`).
+Configures whether to mirror preview image from the camera (`boolean`, default:
+`true`).
 
-This option is useful when taking a selfie with a front camera: when you wave your right hand,
-you will see your hand on the right on the preview screen, like in the mirror.
-But when you actually take a picture, it will not be mirrored. This is how smartphone selfie cameras behave.
+This option is useful when taking a selfie with a front camera: when you wave
+your right hand, you will see your hand on the right on the preview screen, like
+in the mirror. But when you actually take a picture, it will not be mirrored.
+This is how smartphone selfie cameras behave.
 
 #### `videoConstraints`
 
 Configure the [`MediaTrackConstraints`][] (`Object`, default: `{}`).
 
-You can specify acceptable ranges for the resolution of the video stream using the [`aspectRatio`][], [`width`][], and [`height`][] properties. Each property takes an object with `{ min, ideal, max }` properties. For example, use `width: { min: 720, max: 1920, ideal: 1920 }` to allow any width between 720 and 1920 pixels wide, while preferring the highest resolution.
+You can specify acceptable ranges for the resolution of the video stream using
+the [`aspectRatio`][], [`width`][], and [`height`][] properties. Each property
+takes an object with `{ min, ideal, max }` properties. For example, use
+`width: { min: 720, max: 1920, ideal: 1920 }` to allow any width between 720 and
+1920 pixels wide, while preferring the highest resolution.
 
-Devices sometimes have several cameras, front and back, for example. [`facingMode`][] lets you specify which should be used:
+Devices sometimes have several cameras, front and back, for example.
+[`facingMode`][] lets you specify which should be used:
 
-- `user`: The video source is facing toward the user; this includes, for example, the front-facing camera on a smartphone.
-- `environment`: The video source is facing away from the user, thereby viewing their environment. This is the back camera on a smartphone.
-- `left`: The video source is facing toward the user but to their left, such as a camera aimed toward the user but over their left shoulder.
-- `right`: The video source is facing toward the user but to their right, such as a camera aimed toward the user but over their right shoulder.
+- `user`: The video source is facing toward the user; this includes, for
+  example, the front-facing camera on a smartphone.
+- `environment`: The video source is facing away from the user, thereby viewing
+  their environment. This is the back camera on a smartphone.
+- `left`: The video source is facing toward the user but to their left, such as
+  a camera aimed toward the user but over their left shoulder.
+- `right`: The video source is facing toward the user but to their right, such
+  as a camera aimed toward the user but over their right shoulder.
 
-For a full list of available properties, check out MDN documentation for [`MediaTrackConstraints`][].
+For a full list of available properties, check out MDN documentation for
+[`MediaTrackConstraints`][].
 
-[`mediatrackconstraints`]: https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#Properties_of_video_tracks
-[`aspectratio`]: https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints/aspectRatio
-[`width`]: https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints/width
-[`height`]: https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints/height
-[`facingmode`]: https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints/facingMode
+[`mediatrackconstraints`]:
+	https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#Properties_of_video_tracks
+[`aspectratio`]:
+	https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints/aspectRatio
+[`width`]:
+	https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints/width
+[`height`]:
+	https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints/height
+[`facingmode`]:
+	https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints/facingMode
 
 #### `showVideoSourceDropdown`
 
-Configures whether to show a dropdown which enables to choose the video device to use (`boolean`, default: `false`).
+Configures whether to show a dropdown which enables to choose the video device
+to use (`boolean`, default: `false`).
 
 This option will have priority over `facingMode` if enabled.
 
 #### `showRecordingLength`
 
-Configures whether to show the length of the recording while the recording is in progress (`boolean`, default: `false`).
+Configures whether to show the length of the recording while the recording is in
+progress (`boolean`, default: `false`).
 
 #### `preferredVideoMimeType`
 
-Set the preferred mime type for video recordings, for example `'video/webm'` (`string`, default: `null`).
+Set the preferred mime type for video recordings, for example `'video/webm'`
+(`string`, default: `null`).
 
-If the browser supports the given mime type, the video will be recorded in this format.
-If the browser does not support it, it will use the browser default.
-If no preferred video mime type is given, the Webcam plugin will prefer types listed in the [`allowedFileTypes` restriction](/docs/uppy/#restrictions), if any.
+If the browser supports the given mime type, the video will be recorded in this
+format. If the browser does not support it, it will use the browser default. If
+no preferred video mime type is given, the Webcam plugin will prefer types
+listed in the [`allowedFileTypes` restriction](/docs/uppy/#restrictions), if
+any.
 
 #### `preferredImageMimeType`
 
-Set the preferred mime type for images, for example `'image/png'` (`string`, default: `image/jpeg`).
+Set the preferred mime type for images, for example `'image/png'` (`string`,
+default: `image/jpeg`).
 
-If the browser supports rendering the given mime type, the image will be stored in this format.
-Else `image/jpeg` is used by default.
-If no preferred image mime type is given, the Webcam plugin will prefer types listed in the [`allowedFileTypes` restriction](/docs/uppy/#restrictions), if any.
+If the browser supports rendering the given mime type, the image will be stored
+in this format. Else `image/jpeg` is used by default. If no preferred image mime
+type is given, the Webcam plugin will prefer types listed in the
+[`allowedFileTypes` restriction](/docs/uppy/#restrictions), if any.
 
 #### `mobileNativeCamera`
 
-Replaces Uppy’s custom camera UI on mobile and tablet with the native device camera (`Function: boolean` or `boolean`, default: `isMobile()`).
+Replaces Uppy’s custom camera UI on mobile and tablet with the native device
+camera (`Function: boolean` or `boolean`, default: `isMobile()`).
 
-This will show the “Take Picture” and / or “Record Video” buttons, which ones show depends on the [`modes`](#modes) option.
+This will show the “Take Picture” and / or “Record Video” buttons, which ones
+show depends on the [`modes`](#modes) option.
 
-You can set a boolean to forcefully enable / disable this feature,
-or a function which returns a boolean. By default we use the [`is-mobile`](https://github.com/juliangruber/is-mobile) package.
+You can set a boolean to forcefully enable / disable this feature, or a function
+which returns a boolean. By default we use the
+[`is-mobile`](https://github.com/juliangruber/is-mobile) package.
 
 #### `locale`
 

--- a/docs/uploader/aws-s3-multipart.mdx
+++ b/docs/uploader/aws-s3-multipart.mdx
@@ -8,25 +8,36 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # AWS S3 Multipart
 
-The `@uppy/aws-s3-multipart` plugin can be used to upload files directly to an S3 bucket (or S3-compatible provider)
-using S3’s Multipart uploader.
+The `@uppy/aws-s3-multipart` plugin can be used to upload files directly to an
+S3 bucket (or S3-compatible provider) using S3’s Multipart uploader.
 
 ## When should I use it?
 
 :::tip
-Not sure which uploader is best for you? Read “[Choosing the uploader you need](/docs/guides/choosing-uploader)”.
+
+Not sure which uploader is best for you? Read
+“[Choosing the uploader you need](/docs/guides/choosing-uploader)”.
+
 :::
 
-You can use this plugin when you prefer a _client-to-storage_ over a _client-to-server-to-storage_ (such as [Transloadit](/docs/upload-strategies/transloadit) or [Tus](/docs/upload-strategies/tus)) setup.
-This may in some cases be preferable, for instance, to reduce costs or the complexity of running a server and load balancer with [Tus](/docs/upload-strategies/tus).
+You can use this plugin when you prefer a _client-to-storage_ over a
+_client-to-server-to-storage_ (such as
+[Transloadit](/docs/upload-strategies/transloadit) or
+[Tus](/docs/upload-strategies/tus)) setup. This may in some cases be preferable,
+for instance, to reduce costs or the complexity of running a server and load
+balancer with [Tus](/docs/upload-strategies/tus).
 
-`@uppy/aws-s3-multipart` starts to become valuable for larger files (100&nbsp;MB+) as it uploads a single object as a set of parts.
-This has certain benefits, such as improved throughput (uploading parts in parallel) and quick recovery from network issues (only the failed parts need to be retried).
-The downside is request overhead, as it needs to do creation, signing, and completion requests besides the upload requests.
-For example, if you are uploading files that are only a couple kilobytes with a 100ms roundtrip latency,
+`@uppy/aws-s3-multipart` starts to become valuable for larger files
+(100&nbsp;MB+) as it uploads a single object as a set of parts. This has certain
+benefits, such as improved throughput (uploading parts in parallel) and quick
+recovery from network issues (only the failed parts need to be retried). The
+downside is request overhead, as it needs to do creation, signing, and
+completion requests besides the upload requests. For example, if you are
+uploading files that are only a couple kilobytes with a 100ms roundtrip latency,
 you are spending 400ms on overhead and only a few milliseconds on uploading.
 
-If you are uploading large files (100&nbsp;MB+), we recommend `@uppy/aws-s3-multipart`, otherwise [`@uppy/aws-s3`][].
+If you are uploading large files (100&nbsp;MB+), we recommend
+`@uppy/aws-s3-multipart`, otherwise [`@uppy/aws-s3`][].
 
 ## Install
 
@@ -61,15 +72,20 @@ yarn add @uppy/aws-s3-multipart
 
 ### Setting up your S3 bucket
 
-To use this plugin with S3 we need to setup a bucket with the right permissions and CORS settings.
+To use this plugin with S3 we need to setup a bucket with the right permissions
+and CORS settings.
 
-S3 buckets do not allow public uploads for security reasons.
-To allow Uppy and the browser to upload directly to a bucket, its CORS permissions need to be configured.
+S3 buckets do not allow public uploads for security reasons. To allow Uppy and
+the browser to upload directly to a bucket, its CORS permissions need to be
+configured.
 
-CORS permissions can be found in the [S3 Management Console](https://console.aws.amazon.com/s3/home).
-Click the bucket that will receive the uploads, then go into the `Permissions` tab and select the `CORS configuration` button.
-A JSON document will be shown that defines the CORS configuration. (AWS used to use XML but now only allow JSON).
-More information about the [S3 CORS format here](https://docs.amazonaws.cn/en_us/AmazonS3/latest/userguide/ManageCorsUsing.html).
+CORS permissions can be found in the
+[S3 Management Console](https://console.aws.amazon.com/s3/home). Click the
+bucket that will receive the uploads, then go into the `Permissions` tab and
+select the `CORS configuration` button. A JSON document will be shown that
+defines the CORS configuration. (AWS used to use XML but now only allow JSON).
+More information about the
+[S3 CORS format here](https://docs.amazonaws.cn/en_us/AmazonS3/latest/userguide/ManageCorsUsing.html).
 
 The configuration required for Uppy and Companion is this:
 
@@ -95,37 +111,46 @@ The configuration required for Uppy and Companion is this:
 ]
 ```
 
-A good practice is to use two CORS rules: one for viewing the uploaded files, and one for uploading files.
-This is done above where the first object in the array defines the rules for uploading, and the second for viewing.
-The example above **makes files publically viewable**. You can change it according to your needs.
+A good practice is to use two CORS rules: one for viewing the uploaded files,
+and one for uploading files. This is done above where the first object in the
+array defines the rules for uploading, and the second for viewing. The example
+above **makes files publically viewable**. You can change it according to your
+needs.
 
-If you are using an IAM policy to allow access to the S3 bucket, the policy must have at least the `s3:PutObject` and `s3:PutObjectAcl` permissions scoped to the bucket in question.
-In-depth documentation about CORS rules is available on the [AWS documentation site](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html).
+If you are using an IAM policy to allow access to the S3 bucket, the policy must
+have at least the `s3:PutObject` and `s3:PutObjectAcl` permissions scoped to the
+bucket in question. In-depth documentation about CORS rules is available on the
+[AWS documentation site](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html).
 
 ### Use with your own server
 
-The recommended approach is to integrate `@uppy/aws-s3-multipart` with your own server.
-You will need to do the following things:
+The recommended approach is to integrate `@uppy/aws-s3-multipart` with your own
+server. You will need to do the following things:
 
 1. [Setup up a S4 bucket](#setting-up-your-s3-bucket)
-2. Create endpoints in your server. You can create them as edge functions (such as AWS Lambdas),
-   inside Next.js as an API route, or wherever your server runs
+2. Create endpoints in your server. You can create them as edge functions (such
+   as AWS Lambdas), inside Next.js as an API route, or wherever your server runs
    - `POST` > `/uppy/s3`: create the multipart upload
    - `GET` > `/uppy/s3/:id`: get the uploaded parts
-   - `GET` > `/uppy/s3/:id/:partNumber`: sign the part and return a pre-signed URL
+   - `GET` > `/uppy/s3/:id/:partNumber`: sign the part and return a pre-signed
+     URL
    - `POST` > `/uppy/s3/:id/complete`: complete the multipart upload
    - `DELETE` > `/uppy/s3/:id`: abort the multipart upload
 3. [Setup Uppy](https://github.com/transloadit/uppy/blob/main/examples/aws-nodejs/public/index.html)
 
 ### Use with Companion
 
-[Companion](/docs/companion) has S3 routes built-in for a plug-and-play experience with Uppy.
+[Companion](/docs/companion) has S3 routes built-in for a plug-and-play
+experience with Uppy.
 
 :::caution
-Generally it’s better for access control, observability, and scaling to integrate `@uppy/aws-s3-multipart`
-with your own server. You may want to use [Companion](/docs/companion) for creating, signing,
-and completing your S3 uploads if you already need Companion for remote files (such as from Google Drive).
-Otherwise it’s not worth the hosting effort.
+
+Generally it’s better for access control, observability, and scaling to
+integrate `@uppy/aws-s3-multipart` with your own server. You may want to use
+[Companion](/docs/companion) for creating, signing, and completing your S3
+uploads if you already need Companion for remote files (such as from Google
+Drive). Otherwise it’s not worth the hosting effort.
+
 :::
 
 ```js {10} showLineNumbers
@@ -149,8 +174,9 @@ const uppy = new Uppy()
 
 The maximum amount of files to upload in parallel (`number`, default: `6`).
 
-Note that the amount of files is not the same as the amount of concurrent connections.
-Multipart uploads can use many requests per file. For example, for a 100 MB file with a part size of 5 MB:
+Note that the amount of files is not the same as the amount of concurrent
+connections. Multipart uploads can use many requests per file. For example, for
+a 100 MB file with a part size of 5 MB:
 
 - 1 creation request
 - 100/5 = 20 sign requests
@@ -158,9 +184,12 @@ Multipart uploads can use many requests per file. For example, for a 100 MB file
 - 1 complete request
 
 :::caution
-Unless you have a good reason and are well informed about the average internet speed of your users,
-do not set this higher. S3 uses HTTP/1.1, which means a limit to concurrent connections
-and your uploads may expire before they are uploaded.
+
+Unless you have a good reason and are well informed about the average internet
+speed of your users, do not set this higher. S3 uses HTTP/1.1, which means a
+limit to concurrent connections and your uploads may expire before they are
+uploaded.
+
 :::
 
 #### `companionUrl`
@@ -169,65 +198,78 @@ URL to a [Companion](/docs/companion) instance (`string`, default: `null`).
 
 #### `companionHeaders`
 
-Custom headers that should be sent along to [Companion](/docs/companion) on every request (`Object`, default: `{}`).
+Custom headers that should be sent along to [Companion](/docs/companion) on
+every request (`Object`, default: `{}`).
 
 #### `companionCookiesRule`
 
-This option correlates to the [RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) (`string`, default: `'same-origin'`).
+This option correlates to the
+[RequestCredentials value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials)
+(`string`, default: `'same-origin'`).
 
 This tells the plugin whether to send cookies to [Companion](/docs/companion).
 
 #### `retryDelays`
 
-`retryDelays` are the intervals in milliseconds used to retry a failed chunk (`array`, default: `[0, 1000, 3000, 5000]`).
+`retryDelays` are the intervals in milliseconds used to retry a failed chunk
+(`array`, default: `[0, 1000, 3000, 5000]`).
 
-This is also used for [`signPart()`](#signpartfile-partdata).
-Set to `null` to disable automatic retries, and fail instantly if any chunk fails to upload.
+This is also used for [`signPart()`](#signpartfile-partdata). Set to `null` to
+disable automatic retries, and fail instantly if any chunk fails to upload.
 
 #### `getChunkSize(file)`
 
-A function that returns the minimum chunk size to use when uploading the given file.
+A function that returns the minimum chunk size to use when uploading the given
+file.
 
-The S3 Multipart plugin uploads files in chunks.
-Chunks are sent in batches to have presigned URLs generated with [`signPart()`](#signpartfile-partdata).
-To reduce the amount of requests for large files, you can choose a larger chunk size, at the cost of having to re-upload more data if one chunk fails to upload.
+The S3 Multipart plugin uploads files in chunks. Chunks are sent in batches to
+have presigned URLs generated with [`signPart()`](#signpartfile-partdata). To
+reduce the amount of requests for large files, you can choose a larger chunk
+size, at the cost of having to re-upload more data if one chunk fails to upload.
 
-S3 requires a minimum chunk size of 5MB, and supports at most 10,000 chunks per multipart upload.
-If `getChunkSize()` returns a size that’s too small, Uppy will increase it to S3’s minimum requirements.
+S3 requires a minimum chunk size of 5MB, and supports at most 10,000 chunks per
+multipart upload. If `getChunkSize()` returns a size that’s too small, Uppy will
+increase it to S3’s minimum requirements.
 
 #### `createMultipartUpload(file)`
 
 A function that calls the S3 Multipart API to create a new upload.
 
-`file` is the file object from Uppy’s state. The most relevant keys are `file.name` and `file.type`.
+`file` is the file object from Uppy’s state. The most relevant keys are
+`file.name` and `file.type`.
 
 Return a Promise for an object with keys:
 
 - `uploadId` - The UploadID returned by S3.
-- `key` - The object key for the file. This needs to be returned to allow it to be different from the `file.name`.
+- `key` - The object key for the file. This needs to be returned to allow it to
+  be different from the `file.name`.
 
 The default implementation calls out to Companion’s S3 signing endpoints.
 
 #### `listParts(file, { uploadId, key })`
 
-A function that calls the S3 Multipart API to list the parts of a file that have already been uploaded.
+A function that calls the S3 Multipart API to list the parts of a file that have
+already been uploaded.
 
 Receives the `file` object from Uppy’s state, and an object with keys:
 
 - `uploadId` - The UploadID of this Multipart upload.
 - `key` - The object key of this Multipart upload.
 
-Return a Promise for an array of S3 Part objects, as returned by the S3 Multipart API. Each object has keys:
+Return a Promise for an array of S3 Part objects, as returned by the S3
+Multipart API. Each object has keys:
 
 - `PartNumber` - The index in the file of the uploaded part.
 - `Size` - The size of the part in bytes.
-- `ETag` - The ETag of the part, used to identify it when completing the multipart upload and combining all parts into a single file.
+- `ETag` - The ETag of the part, used to identify it when completing the
+  multipart upload and combining all parts into a single file.
 
 The default implementation calls out to Companion’s S3 signing endpoints.
 
 #### `signPart(file, partData)`
 
-A function that generates a signed URL for the specified part number. The `partData` argument is an object with the keys:
+A function that generates a signed URL for the specified part number. The
+`partData` argument is an object with the keys:
 
 - `uploadId` - The UploadID of this Multipart upload.
 - `key` - The object key in the S3 bucket.
@@ -235,10 +277,12 @@ A function that generates a signed URL for the specified part number. The `partD
 - `body` – The data that will be signed.
 - `signal` – An `AbortSignal` that may be used to abort an ongoing request.
 
-This function should return a object, or a promise that resolves to an object, with the following keys:
+This function should return a object, or a promise that resolves to an object,
+with the following keys:
 
 - `url` – the presigned URL, as a `string`.
-- `headers` – **(Optional)** Custom headers to send along with the request to S3 endpoint.
+- `headers` – **(Optional)** Custom headers to send along with the request to S3
+  endpoint.
 
 An example of what the return value should look like:
 
@@ -251,36 +295,42 @@ An example of what the return value should look like:
 
 #### `abortMultipartUpload(file, { uploadId, key })`
 
-A function that calls the S3 Multipart API to abort a Multipart upload, and removes all parts that have been uploaded so far.
+A function that calls the S3 Multipart API to abort a Multipart upload, and
+removes all parts that have been uploaded so far.
 
 Receives the `file` object from Uppy’s state, and an object with keys:
 
 - `uploadId` - The UploadID of this Multipart upload.
 - `key` - The object key of this Multipart upload.
 
-This is typically called when the user cancels an upload. Cancellation cannot fail in Uppy, so the result of this function is ignored.
+This is typically called when the user cancels an upload. Cancellation cannot
+fail in Uppy, so the result of this function is ignored.
 
 The default implementation calls out to Companion’s S3 signing endpoints.
 
 #### `completeMultipartUpload(file, { uploadId, key, parts })`
 
-A function that calls the S3 Multipart API to complete a Multipart upload, combining all parts into a single object in the S3 bucket.
+A function that calls the S3 Multipart API to complete a Multipart upload,
+combining all parts into a single object in the S3 bucket.
 
 Receives the `file` object from Uppy’s state, and an object with keys:
 
 - `uploadId` - The UploadID of this Multipart upload.
 - `key` - The object key of this Multipart upload.
-- `parts` - S3-style list of parts, an array of objects with `ETag` and `PartNumber` properties. This can be passed straight to S3’s Multipart API.
+- `parts` - S3-style list of parts, an array of objects with `ETag` and
+  `PartNumber` properties. This can be passed straight to S3’s Multipart API.
 
 Return a Promise for an object with properties:
 
-- `location` - **(Optional)** A publically accessible URL to the object in the S3 bucket.
+- `location` - **(Optional)** A publically accessible URL to the object in the
+  S3 bucket.
 
 The default implementation calls out to Companion’s S3 signing endpoints.
 
 #### `allowedMetaFields: null`
 
-Pass an array of field names to limit the metadata fields that will be added to upload as query parameters.
+Pass an array of field names to limit the metadata fields that will be added to
+upload as query parameters.
 
 - Set this to `['name']` to only send the `name` field.
 - Set this to `null` (the default) to send _all_ metadata fields.
@@ -293,17 +343,22 @@ Pass an array of field names to limit the metadata fields that will be added to 
 
 A function that generates a batch of signed URLs for the specified part numbers.
 
-Receives the `file` object from Uppy’s state. The `partData` argument is an object with keys:
+Receives the `file` object from Uppy’s state. The `partData` argument is an
+object with keys:
 
 - `uploadId` - The UploadID of this Multipart upload.
 - `key` - The object key in the S3 bucket.
-- `parts` - An array of objects with the part number and chunk (`Array<{ number: number, chunk: blob }>`). `number` can’t be zero.
+- `parts` - An array of objects with the part number and chunk
+  (`Array<{ number: number, chunk: blob }>`). `number` can’t be zero.
 
 `prepareUploadParts` should return a `Promise` with an `Object` with keys:
 
-- `presignedUrls` - A JavaScript object with the part numbers as keys and the presigned URL for each part as the value.
-- `headers` - **(Optional)** Custom headers to send along with every request per part (`{ 1: { 'Content-MD5': 'hash' }}`).
-  These are (1-based) indexed by part number too so you can for instance send the MD5 hash validation for each part to S3.
+- `presignedUrls` - A JavaScript object with the part numbers as keys and the
+  presigned URL for each part as the value.
+- `headers` - **(Optional)** Custom headers to send along with every request per
+  part (`{ 1: { 'Content-MD5': 'hash' }}`). These are (1-based) indexed by part
+  number too so you can for instance send the MD5 hash validation for each part
+  to S3.
 
 An example of what the return value should look like:
 
@@ -322,13 +377,16 @@ An example of what the return value should look like:
 }
 ```
 
-If an error occured, reject the `Promise` with an `Object` with the following keys:
+If an error occured, reject the `Promise` with an `Object` with the following
+keys:
 
 ```json
 { "source": { "status": 500 } }
 ```
 
-`status` is the HTTP code and is required for determining whether to retry the request. `prepareUploadParts` will be retried if the code is `0`, `409`, `423`, or between `500` and `600`.
+`status` is the HTTP code and is required for determining whether to retry the
+request. `prepareUploadParts` will be retried if the code is `0`, `409`, `423`,
+or between `500` and `600`.
 
 </details>
 

--- a/docs/uploader/aws-s3.mdx
+++ b/docs/uploader/aws-s3.mdx
@@ -8,25 +8,35 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # AWS S3
 
-The `@uppy/aws-s3` plugin can be used to upload files directly to a S3 bucket or a S3-compatible provider,
-such as Google Cloud Storage or DigitalOcean Spaces.
-Uploads can be signed using either [Companion][companion docs] or a custom signing function.
+The `@uppy/aws-s3` plugin can be used to upload files directly to a S3 bucket or
+a S3-compatible provider, such as Google Cloud Storage or DigitalOcean Spaces.
+Uploads can be signed using either [Companion][companion docs] or a custom
+signing function.
 
 ## When should I use it?
 
 :::tip
-Not sure which uploader is best for you? Read “[Choosing the uploader you need](/docs/guides/choosing-uploader)”.
+
+Not sure which uploader is best for you? Read
+“[Choosing the uploader you need](/docs/guides/choosing-uploader)”.
+
 :::
 
-You can use this plugin when you prefer a _client-to-storage_ over a _client-to-server-to-storage_ (such as [Transloadit](/docs/upload-strategies/transloadit) or [Tus](/docs/upload-strategies/tus)) setup.
-This may in some cases be preferable, for instance, to reduce costs or the complexity of running a server and load balancer with [Tus](/docs/upload-strategies/tus).
+You can use this plugin when you prefer a _client-to-storage_ over a
+_client-to-server-to-storage_ (such as
+[Transloadit](/docs/upload-strategies/transloadit) or
+[Tus](/docs/upload-strategies/tus)) setup. This may in some cases be preferable,
+for instance, to reduce costs or the complexity of running a server and load
+balancer with [Tus](/docs/upload-strategies/tus).
 
-This plugin can be used with AWS S3, DigitalOcean Spaces, Google Cloud Storage, or any S3-compatible provider.
-Although all S3-compatible providers are supported, we don’t test against them, this plugin was developed against S3
-so a small risk is involved in using the others.
+This plugin can be used with AWS S3, DigitalOcean Spaces, Google Cloud Storage,
+or any S3-compatible provider. Although all S3-compatible providers are
+supported, we don’t test against them, this plugin was developed against S3 so a
+small risk is involved in using the others.
 
-`@uppy/aws-s3` is best suited for small files and/or lots of files.
-If you are planning to upload mostly large files (100&nbsp;MB+), consider using [`@uppy/aws-s3-multipart`](/docs/upload-strategies/aws-s3-multipart).
+`@uppy/aws-s3` is best suited for small files and/or lots of files. If you are
+planning to upload mostly large files (100&nbsp;MB+), consider using
+[`@uppy/aws-s3-multipart`](/docs/upload-strategies/aws-s3-multipart).
 
 ## Install
 
@@ -76,15 +86,20 @@ const uppy = new Uppy()
 
 ### With a AWS S3 bucket
 
-To use this plugin with S3 we need to setup a bucket with the right permissions and CORS settings.
+To use this plugin with S3 we need to setup a bucket with the right permissions
+and CORS settings.
 
-S3 buckets do not allow public uploads for security reasons.
-To allow Uppy and the browser to upload directly to a bucket, its CORS permissions need to be configured.
+S3 buckets do not allow public uploads for security reasons. To allow Uppy and
+the browser to upload directly to a bucket, its CORS permissions need to be
+configured.
 
-CORS permissions can be found in the [S3 Management Console](https://console.aws.amazon.com/s3/home).
-Click the bucket that will receive the uploads, then go into the `Permissions` tab and select the `CORS configuration` button.
-A JSON document will be shown that defines the CORS configuration. (AWS used to use XML but now only allow JSON).
-More information about the [S3 CORS format here](https://docs.amazonaws.cn/en_us/AmazonS3/latest/userguide/ManageCorsUsing.html).
+CORS permissions can be found in the
+[S3 Management Console](https://console.aws.amazon.com/s3/home). Click the
+bucket that will receive the uploads, then go into the `Permissions` tab and
+select the `CORS configuration` button. A JSON document will be shown that
+defines the CORS configuration. (AWS used to use XML but now only allow JSON).
+More information about the
+[S3 CORS format here](https://docs.amazonaws.cn/en_us/AmazonS3/latest/userguide/ManageCorsUsing.html).
 
 The configuration required for Uppy and Companion is this:
 
@@ -109,24 +124,33 @@ The configuration required for Uppy and Companion is this:
 ]
 ```
 
-A good practice is to use two CORS rules: one for viewing the uploaded files, and one for uploading files.
-This is done above where the first object in the array defines the rules for uploading, and the second for viewing.
-The example above **makes files publically viewable**. You can change it according to your needs.
+A good practice is to use two CORS rules: one for viewing the uploaded files,
+and one for uploading files. This is done above where the first object in the
+array defines the rules for uploading, and the second for viewing. The example
+above **makes files publically viewable**. You can change it according to your
+needs.
 
-If you are using an IAM policy to allow access to the S3 bucket, the policy must have at least the `s3:PutObject` and `s3:PutObjectAcl` permissions scoped to the bucket in question.
-In-depth documentation about CORS rules is available on the [AWS documentation site](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html).
+If you are using an IAM policy to allow access to the S3 bucket, the policy must
+have at least the `s3:PutObject` and `s3:PutObjectAcl` permissions scoped to the
+bucket in question. In-depth documentation about CORS rules is available on the
+[AWS documentation site](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html).
 
 ### With a DigitalOcean Spaces bucket
 
 :::tip
-Checkout the [DigitalOcean Spaces example](https://github.com/transloadit/uppy/tree/main/examples/digitalocean-spaces) in the Uppy repository
-for a complete, runnable example.
+
+Checkout the
+[DigitalOcean Spaces example](https://github.com/transloadit/uppy/tree/main/examples/digitalocean-spaces)
+in the Uppy repository for a complete, runnable example.
+
 :::
 
-DigitalOcean Spaces is S3-compatible so you only need to change the endpoint and bucket.
-Make sure you have a `key` and `secret`. If not, refer to “[How To Create a DigitalOcean Space and API Key](https://www.digitalocean.com/community/tutorials/how-to-create-a-digitalocean-space-and-api-key)”.
+DigitalOcean Spaces is S3-compatible so you only need to change the endpoint and
+bucket. Make sure you have a `key` and `secret`. If not, refer to
+“[How To Create a DigitalOcean Space and API Key](https://www.digitalocean.com/community/tutorials/how-to-create-a-digitalocean-space-and-api-key)”.
 
-When using [Companion](/docs/companion) as standalone, you can set these as environment variables:
+When using [Companion](/docs/companion) as standalone, you can set these as
+environment variables:
 
 ```bash
 export COMPANION_AWS_KEY="xxx"
@@ -136,9 +160,11 @@ export COMPANION_AWS_ENDPOINT="https://{region}.digitaloceanspaces.com"
 export COMPANION_AWS_BUCKET="my-space-name"
 ```
 
-The `{region}` string will be replaced by the contents of the `COMPANION_AWS_REGION` environment variable.
+The `{region}` string will be replaced by the contents of the
+`COMPANION_AWS_REGION` environment variable.
 
-When using [Companion](/docs/companion) as an Express integration, configure the `s3` options:
+When using [Companion](/docs/companion) as an Express integration, configure the
+`s3` options:
 
 ```js
 const options = {
@@ -154,10 +180,13 @@ const options = {
 
 ### With a Google Cloud Storage bucket
 
-For the `@uppy/aws-s3` plugin to be able to upload to a GCS bucket, it needs the Interoperability setting enabled.
-You can enable the Interoperability setting and [generate interoperable storage access keys](https://cloud.google.com/storage/docs/migrating#keys)
-by going to [Google Cloud Storage](https://console.cloud.google.com/storage) » Settings » Interoperability.
-Then set the environment variables for Companion like this:
+For the `@uppy/aws-s3` plugin to be able to upload to a GCS bucket, it needs the
+Interoperability setting enabled. You can enable the Interoperability setting
+and
+[generate interoperable storage access keys](https://cloud.google.com/storage/docs/migrating#keys)
+by going to [Google Cloud Storage](https://console.cloud.google.com/storage) »
+Settings » Interoperability. Then set the environment variables for Companion
+like this:
 
 ```bash
 export COMPANION_AWS_ENDPOINT="https://storage.googleapis.com"
@@ -168,12 +197,14 @@ export COMPANION_AWS_SECRET="YOUR-GCS-SECRET" # The Secret
 
 You do not need to configure the region with GCS.
 
-You also need to configure CORS with their HTTP API.
-If you haven’t done this already, see [Configuring CORS on a Bucket](https://cloud.google.com/storage/docs/configuring-cors#Configuring-CORS-on-a-Bucket) in the GCS documentation,
-or follow the steps below to do it using Google’s API playground.
+You also need to configure CORS with their HTTP API. If you haven’t done this
+already, see
+[Configuring CORS on a Bucket](https://cloud.google.com/storage/docs/configuring-cors#Configuring-CORS-on-a-Bucket)
+in the GCS documentation, or follow the steps below to do it using Google’s API
+playground.
 
-The JSON format consists of an array of CORS configuration objects.
-For instance:
+The JSON format consists of an array of CORS configuration objects. For
+instance:
 
 ```json
 {
@@ -192,10 +223,13 @@ For instance:
 }
 ```
 
-When using presigned `PUT` uploads, replace the `"POST"` method by `"PUT"` in the first entry.
+When using presigned `PUT` uploads, replace the `"POST"` method by `"PUT"` in
+the first entry.
 
-If you have the [gsutil](https://cloud.google.com/storage/docs/gsutil) command-line tool,
-you can apply this configuration using the [gsutil cors](https://cloud.google.com/storage/docs/configuring-cors#configure-cors-bucket) command.
+If you have the [gsutil](https://cloud.google.com/storage/docs/gsutil)
+command-line tool, you can apply this configuration using the
+[gsutil cors](https://cloud.google.com/storage/docs/configuring-cors#configure-cors-bucket)
+command.
 
 ```bash
 gsutil cors set THAT-FILE.json gs://BUCKET-NAME
@@ -203,7 +237,8 @@ gsutil cors set THAT-FILE.json gs://BUCKET-NAME
 
 Otherwise, you can manually apply it through the OAuth playground:
 
-1.  Get a temporary API token from the [Google OAuth2.0 playground](https://developers.google.com/oauthplayground/)
+1.  Get a temporary API token from the
+    [Google OAuth2.0 playground](https://developers.google.com/oauthplayground/)
 2.  Select the `Cloud Storage JSON API v1` » `devstorage.full_control` scope
 3.  Press `Authorize APIs` and allow access
 4.  Click `Step 3 - Configure request to API`
@@ -216,24 +251,28 @@ Otherwise, you can manually apply it through the OAuth playground:
 
 ### Use with your own server
 
-The recommended approach is to integrate `@uppy/aws-s3-multipart` with your own server.
-You will need to do the following things:
+The recommended approach is to integrate `@uppy/aws-s3-multipart` with your own
+server. You will need to do the following things:
 
 1. Setup a bucket
-2. Create endpoints in your server. You can create them as edge functions (such as AWS Lambdas),
-   inside Next.js as an API route, or wherever your server runs
+2. Create endpoints in your server. You can create them as edge functions (such
+   as AWS Lambdas), inside Next.js as an API route, or wherever your server runs
    - `POST` > `/uppy/s3`: get upload parameters
 3. [Setup Uppy](https://github.com/transloadit/uppy/blob/main/examples/aws-nodejs/public/index.html)
 
 ### Use with Companion
 
-[Companion](/docs/companion) has S3 routes built-in for a plug-and-play experience with Uppy.
+[Companion](/docs/companion) has S3 routes built-in for a plug-and-play
+experience with Uppy.
 
 :::caution
-Generally it’s better for access control, observability, and scaling to integrate `@uppy/aws-s3`
-with your own server. You may want to use [Companion](/docs/companion) for creating, signing,
-and completing your S3 uploads if you already need Companion for remote files (such as from Google Drive).
-Otherwise it’s not worth the hosting effort.
+
+Generally it’s better for access control, observability, and scaling to
+integrate `@uppy/aws-s3` with your own server. You may want to use
+[Companion](/docs/companion) for creating, signing, and completing your S3
+uploads if you already need Companion for remote files (such as from Google
+Drive). Otherwise it’s not worth the hosting effort.
+
 :::
 
 ```js {10} showLineNumbers
@@ -264,11 +303,13 @@ Companion instance to use for signing S3 uploads (`string`, default: `null`).
 
 #### `companionHeaders`
 
-Custom headers that should be sent along to [Companion](/docs/companion) on every request (`Object`, default: `{}`).
+Custom headers that should be sent along to [Companion](/docs/companion) on
+every request (`Object`, default: `{}`).
 
 #### `allowedMetaFields`
 
-Pass an array of field names to limit the metadata fields that will be added to upload as query parameters (`Array`, default: `null`).
+Pass an array of field names to limit the metadata fields that will be added to
+upload as query parameters (`Array`, default: `null`).
 
 - Set this to `['name']` to only send the `name` field.
 - Set this to `null` (the default) to send _all_ metadata fields.
@@ -277,48 +318,65 @@ Pass an array of field names to limit the metadata fields that will be added to 
 #### `getUploadParameters(file)`
 
 :::note
-When using [Companion][companion docs] to sign S3 uploads, do not define this option.
+
+When using [Companion][companion docs] to sign S3 uploads, do not define this
+option.
+
 :::
 
-A function that returns upload parameters for a file (`Promise`, default: `null`).
+A function that returns upload parameters for a file (`Promise`, default:
+`null`).
 
-Parameters should be returned as an object, or as a `Promise` that fulfills with an object, with keys `{ method, url, fields, headers }`.
+Parameters should be returned as an object, or as a `Promise` that fulfills with
+an object, with keys `{ method, url, fields, headers }`.
 
-- The `method` field is the HTTP method to be used for the upload.
-  This should be one of either `PUT` or `POST`, depending on the type of upload used.
-- The `url` field is the URL to which the upload request will be sent.
-  When using a presigned PUT upload, this should be the URL to the S3 object with signing parameters included in the query string.
-  When using a POST upload with a policy document, this should be the root URL of the bucket.
-- The `fields` field is an object with form fields to send along with the upload request.
-  For presigned PUT uploads, this should be left empty.
-- The `headers` field is an object with request headers to send along with the upload request.
-  When using a presigned PUT upload, it’s a good idea to provide `headers['content-type']`. That will make sure that the request uses the same content-type that was used to generate the signature. Without it, the browser may decide on a different content-type instead, causing S3 to reject the upload.
+- The `method` field is the HTTP method to be used for the upload. This should
+  be one of either `PUT` or `POST`, depending on the type of upload used.
+- The `url` field is the URL to which the upload request will be sent. When
+  using a presigned PUT upload, this should be the URL to the S3 object with
+  signing parameters included in the query string. When using a POST upload with
+  a policy document, this should be the root URL of the bucket.
+- The `fields` field is an object with form fields to send along with the upload
+  request. For presigned PUT uploads, this should be left empty.
+- The `headers` field is an object with request headers to send along with the
+  upload request. When using a presigned PUT upload, it’s a good idea to provide
+  `headers['content-type']`. That will make sure that the request uses the same
+  content-type that was used to generate the signature. Without it, the browser
+  may decide on a different content-type instead, causing S3 to reject the
+  upload.
 
 #### `timeout`
 
-When no upload progress events have been received for this amount of milliseconds, assume the connection has an issue and abort the upload (`number`, default: `30_000`).
+When no upload progress events have been received for this amount of
+milliseconds, assume the connection has an issue and abort the upload (`number`,
+default: `30_000`).
 
-This is passed through to [XHRUpload](/docs/xhrupload#timeout-30-1000); see its documentation page for details.
-Set to `0` to disable this check.
+This is passed through to [XHRUpload](/docs/xhrupload#timeout-30-1000); see its
+documentation page for details. Set to `0` to disable this check.
 
 #### `limit`
 
 Limit the amount of uploads going on at the same time (`number`, default: `5`).
 
-Setting this to `0` means no limit on concurrent uploads, but we recommend a value between `5` and `20`.
+Setting this to `0` means no limit on concurrent uploads, but we recommend a
+value between `5` and `20`.
 
 #### `getResponseData(responseText, response)`
 
 :::note
-This is an advanced option intended for use with _almost_ S3-compatible storage solutions.
+
+This is an advanced option intended for use with _almost_ S3-compatible storage
+solutions.
+
 :::
 
-Customize response handling once an upload is completed.
-This passes the function through to @uppy/xhr-upload,
-see its [documentation](https://uppy.io/docs/xhr-upload/#getResponseData-responseText-response) for API details.
+Customize response handling once an upload is completed. This passes the
+function through to @uppy/xhr-upload, see its
+[documentation](https://uppy.io/docs/xhr-upload/#getResponseData-responseText-response)
+for API details.
 
-This option is useful when uploading to an S3-like service that doesn’t reply with an XML document,
-but with something else such as JSON.
+This option is useful when uploading to an S3-like service that doesn’t reply
+with an XML document, but with something else such as JSON.
 
 #### `locale: {}`
 
@@ -334,9 +392,10 @@ export default {
 
 ### How can I generate a presigned URL server-side?
 
-The `getUploadParameters` function can return a `Promise`, so upload parameters can be prepared server-side.
-That way, no private keys to the S3 bucket need to be shared on the client.
-For example, there could be a PHP server endpoint that prepares a presigned URL for a file:
+The `getUploadParameters` function can return a `Promise`, so upload parameters
+can be prepared server-side. That way, no private keys to the S3 bucket need to
+be shared on the client. For example, there could be a PHP server endpoint that
+prepares a presigned URL for a file:
 
 ```js
 uppy.use(AwsS3, {
@@ -374,7 +433,9 @@ uppy.use(AwsS3, {
 });
 ```
 
-See the [aws-presigned-url example in the uppy repository](https://github.com/transloadit/uppy/tree/main/examples/aws-presigned-url) for a small example that implements both the server-side and the client-side.
+See the
+[aws-presigned-url example in the uppy repository](https://github.com/transloadit/uppy/tree/main/examples/aws-presigned-url)
+for a small example that implements both the server-side and the client-side.
 
 ### How can I retrieve the presigned parameters of the uploaded file?
 

--- a/docs/uploader/transloadit.mdx
+++ b/docs/uploader/transloadit.mdx
@@ -8,27 +8,33 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # Transloadit
 
-The `@uppy/transloadit` plugin can be used to upload files directly to [Transloadit](https://transloadit.com/) for all kinds of processing,
-such as transcoding video, resizing images, zipping/unzipping, [and much more][transloadit-services].
+The `@uppy/transloadit` plugin can be used to upload files directly to
+[Transloadit](https://transloadit.com/) for all kinds of processing, such as
+transcoding video, resizing images, zipping/unzipping, [and much
+more][transloadit-services].
 
 ## When should I use it?
 
 :::tip
-Not sure which uploader is best for you? Read “[Choosing the uploader you need](/docs/guides/choosing-uploader)”.
+
+Not sure which uploader is best for you? Read
+“[Choosing the uploader you need](/docs/guides/choosing-uploader)”.
+
 :::
 
-Transloadit’s strength is versatility.
-By doing video, audio, images, documents, and more,
-you only need one vendor for [all your file processing needs][transloadit-services].
-The `@uppy/transloadit` plugin directly uploads to Transloadit
-so you only have to worry about creating a [Template][transloadit-concepts].
-Transloadit accepts the files, processes according to the instructions in the Template,
-and stores the results in storage of your choosing, such as a self-owned S3 bucket.
-The Transloadit plugin uses [Tus](/docs/upload-strategies/tus) under the hood so you don’t have to sacrifice reliable, resumable uploads.
+Transloadit’s strength is versatility. By doing video, audio, images, documents,
+and more, you only need one vendor for [all your file processing
+needs][transloadit-services]. The `@uppy/transloadit` plugin directly uploads to
+Transloadit so you only have to worry about creating a
+[Template][transloadit-concepts]. Transloadit accepts the files, processes
+according to the instructions in the Template, and stores the results in storage
+of your choosing, such as a self-owned S3 bucket. The Transloadit plugin uses
+[Tus](/docs/upload-strategies/tus) under the hood so you don’t have to sacrifice
+reliable, resumable uploads.
 
-You should use `@uppy/transloadit` if you don’t want to host your own Tus or Companion servers,
-(optionally) need file processing, and store it in the service (such as S3 or GCS) of your liking.
-All with minimal effort.
+You should use `@uppy/transloadit` if you don’t want to host your own Tus or
+Companion servers, (optionally) need file processing, and store it in the
+service (such as S3 or GCS) of your liking. All with minimal effort.
 
 ## Install
 
@@ -92,11 +98,15 @@ uppy.on('transloadit:complete', (assembly) => {});
 ### Use with Companion
 
 :::note
-All [Transloadit plans](https://transloadit/pricing/) come with a hosted version of Companion.
+
+All [Transloadit plans](https://transloadit/pricing/) come with a hosted version
+of Companion.
+
 :::
 
-You can use this plugin together with Transloadit’s hosted Companion service to let your users import files from third party sources across the web.
-To do so each provider plugin must be configured with Transloadit’s Companion URLs:
+You can use this plugin together with Transloadit’s hosted Companion service to
+let your users import files from third party sources across the web. To do so
+each provider plugin must be configured with Transloadit’s Companion URLs:
 
 ```js
 import { COMPANION_URL, COMPANION_ALLOWED_HOSTS } from '@uppy/transloadit';
@@ -108,16 +118,18 @@ uppy.use(Dropbox, {
 });
 ```
 
-This will already work.
-Transloadit’s OAuth applications are used to authenticate your users by default.
-Your users will be asked to provide Transloadit access to their files.
-Since your users are probably not aware of Transloadit, this may be confusing or decrease trust.
-You may also hit rate limits, because the OAuth application is shared between everyone using Transloadit.
+This will already work. Transloadit’s OAuth applications are used to
+authenticate your users by default. Your users will be asked to provide
+Transloadit access to their files. Since your users are probably not aware of
+Transloadit, this may be confusing or decrease trust. You may also hit rate
+limits, because the OAuth application is shared between everyone using
+Transloadit.
 
-To solve that, you can use your own OAuth keys with Transloadit’s hosted Companion servers by using Transloadit Template Credentials.
-[Create a Template Credential][template-credentials] on the Transloadit site.
-Select “Companion OAuth” for the service, and enter the key and secret for the provider you want to use.
-Then you can pass the name of the new credentials to that provider:
+To solve that, you can use your own OAuth keys with Transloadit’s hosted
+Companion servers by using Transloadit Template Credentials. [Create a Template
+Credential][template-credentials] on the Transloadit site. Select “Companion
+OAuth” for the service, and enter the key and secret for the provider you want
+to use. Then you can pass the name of the new credentials to that provider:
 
 ```js
 import { COMPANION_URL, COMPANION_ALLOWED_HOSTS } from '@uppy/transloadit';
@@ -143,22 +155,28 @@ A unique identifier for this plugin (`string`, default: `'Transloadit'`).
 
 #### `service`
 
-The Transloadit API URL to use (`string`, default: `https://api2.transloadit.com`).
+The Transloadit API URL to use (`string`, default:
+`https://api2.transloadit.com`).
 
-The default will try to route traffic efficiently based on the location of your users.
-You could for instance set it to `https://api2-us-east-1.transloadit.com` if you need the traffic to stay inside a particular region.
+The default will try to route traffic efficiently based on the location of your
+users. You could for instance set it to `https://api2-us-east-1.transloadit.com`
+if you need the traffic to stay inside a particular region.
 
 #### `limit`
 
 Limit the amount of uploads going on at the same time (`number`, default: `5`).
 
-Setting this to `0` means no limit on concurrent uploads, but we recommend a value between `5` and `20`.
-This option is passed through to the [`@uppy/tus`](/docs/upload-strategies/tus) plugin, which this plugin uses internally.
+Setting this to `0` means no limit on concurrent uploads, but we recommend a
+value between `5` and `20`. This option is passed through to the
+[`@uppy/tus`](/docs/upload-strategies/tus) plugin, which this plugin uses
+internally.
 
 #### `assemblyOptions`
 
-Configure the [Assembly Instructions](https://transloadit.com/docs/topics/assembly-instructions/),
-the fields to send along to the assembly, and authentication (`object | function`, default: `null`).
+Configure the
+[Assembly Instructions](https://transloadit.com/docs/topics/assembly-instructions/),
+the fields to send along to the assembly, and authentication
+(`object | function`, default: `null`).
 
 The object you can pass or return from a function has this structure:
 
@@ -179,26 +197,40 @@ The object you can pass or return from a function has this structure:
 }
 ```
 
-- `params` is used to authenticate with Transloadit and using your desired [template](https://transloadit.com/docs/topics/templates/).
-  - `auth.key` _(required)_ is your authentication key which you can find on the “Credentials” page of your account.
-  - `template_id` _(required)_ is the unique identifier to use the right template from your account.
-  - `steps` _(optional)_ can be used to [overrule Templates at runtime](https://transloadit.com/docs/topics/templates/#overruling-templates-at-runtime).
-    A typical use case might be changing the storage path on the fly based on the session user id.
-    For most use cases, we recommend to let your Templates handle dynamic cases (they can accept `fields` and execute arbitrary JavaScript as well), and not pass in `steps` from a browser.
-    The template editor also has extra validations and context.
+- `params` is used to authenticate with Transloadit and using your desired
+  [template](https://transloadit.com/docs/topics/templates/).
+  - `auth.key` _(required)_ is your authentication key which you can find on the
+    “Credentials” page of your account.
+  - `template_id` _(required)_ is the unique identifier to use the right
+    template from your account.
+  - `steps` _(optional)_ can be used to
+    [overrule Templates at runtime](https://transloadit.com/docs/topics/templates/#overruling-templates-at-runtime).
+    A typical use case might be changing the storage path on the fly based on
+    the session user id. For most use cases, we recommend to let your Templates
+    handle dynamic cases (they can accept `fields` and execute arbitrary
+    JavaScript as well), and not pass in `steps` from a browser. The template
+    editor also has extra validations and context.
   - `notify_url` _(optional)_ is a pingback with the assembly status as JSON.
-    For instance, if you don’t want to block the user experience by letting them wait for your template to complete with [`waitForEncoding`](#waitForEncoding),
-    but you do want to want to asynchrounously have an update, you can provide an URL which will be “pinged” with the assembly status.
-- `signature` _(optional, but recommended)_ is a cryptographic signature to provide further trust in unstrusted environments.
-  Refer to “[Signature Authentication”](https://transloadit.com/docs/topics/signature-authentication/) for more information.
-- `fields` _(optional)_ can be used to to send along key/value pairs, which can be [used dynamically in your template](https://transloadit.com/docs/topics/assembly-instructions/#form-fields-in-instructions).
+    For instance, if you don’t want to block the user experience by letting them
+    wait for your template to complete with
+    [`waitForEncoding`](#waitForEncoding), but you do want to want to
+    asynchrounously have an update, you can provide an URL which will be
+    “pinged” with the assembly status.
+- `signature` _(optional, but recommended)_ is a cryptographic signature to
+  provide further trust in unstrusted environments. Refer to
+  “[Signature Authentication”](https://transloadit.com/docs/topics/signature-authentication/)
+  for more information.
+- `fields` _(optional)_ can be used to to send along key/value pairs, which can
+  be
+  [used dynamically in your template](https://transloadit.com/docs/topics/assembly-instructions/#form-fields-in-instructions).
 
 <details>
   <summary>Examples</summary>
 
 **As a function**
 
-A custom `assemblyOptions()` option should return an object or a promise for an object.
+A custom `assemblyOptions()` option should return an object or a promise for an
+object.
 
 ```js
 uppy.use(Transloadit, {
@@ -216,9 +248,13 @@ uppy.use(Transloadit, {
 });
 ```
 
-The `${fields.caption}` variable will be available in the Assembly spawned from Template `xyz`. You can use this to dynamically watermark images for example.
+The `${fields.caption}` variable will be available in the Assembly spawned from
+Template `xyz`. You can use this to dynamically watermark images for example.
 
-`assemblyOptions()` may also return a Promise, so it could retrieve signed Assembly parameters from a server. For example, assuming an endpoint `/transloadit-params` that responds with a JSON object with `{ params, signature }` properties:
+`assemblyOptions()` may also return a Promise, so it could retrieve signed
+Assembly parameters from a server. For example, assuming an endpoint
+`/transloadit-params` that responds with a JSON object with
+`{ params, signature }` properties:
 
 ```js
 uppy.use(Transloadit, {
@@ -231,7 +267,8 @@ uppy.use(Transloadit, {
 
 **As an object**
 
-If you don’t need to change anything dynamically, you can also pass an object directly.
+If you don’t need to change anything dynamically, you can also pass an object
+directly.
 
 ```js
 uppy.use(Transloadit, {
@@ -243,7 +280,8 @@ uppy.use(Transloadit, {
 
 **Use with @uppy/form**
 
-Combine the `assemblyOptions()` option with the [Form](/docs/form) plugin to pass user input from a `<form>` to a Transloadit Assembly:
+Combine the `assemblyOptions()` option with the [Form](/docs/form) plugin to
+pass user input from a `<form>` to a Transloadit Assembly:
 
 ```js
 // This will add form field values to each file's `.meta` object:
@@ -266,42 +304,58 @@ uppy.use(Transloadit, {
 </details>
 
 :::caution
-When you go to production always make sure to set the `signature`.
-**Not using [Signature Authentication](https://transloadit.com/docs/topics/signature-authentication/) can be a security risk**.
-Signature Authentication is a security measure that can prevent outsiders from tampering with your Assembly Instructions.
-While Signature Authentication is not implemented (yet),
-we recommend to disable `allow_steps_override` in your Templates to avoid outsiders being able to pass in any Instructions and storage targets on your behalf.
+
+When you go to production always make sure to set the `signature`. **Not using
+[Signature Authentication](https://transloadit.com/docs/topics/signature-authentication/)
+can be a security risk**. Signature Authentication is a security measure that
+can prevent outsiders from tampering with your Assembly Instructions. While
+Signature Authentication is not implemented (yet), we recommend to disable
+`allow_steps_override` in your Templates to avoid outsiders being able to pass
+in any Instructions and storage targets on your behalf.
+
 :::
 
 #### `waitForEncoding`
 
-Wait for the template to finish, rather than only the upload, before marking the upload complete (`boolean`, default: `false`).
+Wait for the template to finish, rather than only the upload, before marking the
+upload complete (`boolean`, default: `false`).
 
-- When `false`, the Assemblies will complete (or error) in the background but Uppy won’t know or care about it.
-  You may have to let Transloadit ping you via a `notify_url` and asynchronously inform your user (email, in-app notification).
-- When `true`, the Transloadit plugin waits for Assemblies to complete before the files are marked as completed.
-  This means users have to wait for a potentially long time, depending on how complicated your Assembly instructions are.
-  But, you can receive the final status and transcoding results on the client side with less effort.
+- When `false`, the Assemblies will complete (or error) in the background but
+  Uppy won’t know or care about it. You may have to let Transloadit ping you via
+  a `notify_url` and asynchronously inform your user (email, in-app
+  notification).
+- When `true`, the Transloadit plugin waits for Assemblies to complete before
+  the files are marked as completed. This means users have to wait for a
+  potentially long time, depending on how complicated your Assembly instructions
+  are. But, you can receive the final status and transcoding results on the
+  client side with less effort.
 
-When this is enabled, you can listen for the [`transloadit:result`](#transloaditresult) and [`transloadit:complete`](#transloaditcomplete) events.
+When this is enabled, you can listen for the
+[`transloadit:result`](#transloaditresult) and
+[`transloadit:complete`](#transloaditcomplete) events.
 
 #### `waitForMetadata`
 
-Wait for for Transloadit’s backend to catch early errors, not the entire Assembly to complete. (`boolean`, default: `false`)
+Wait for for Transloadit’s backend to catch early errors, not the entire
+Assembly to complete. (`boolean`, default: `false`)
 
-When set to `true`, the Transloadit plugin waits for Transloadit’s backend to extract metadata from all the uploaded files.
-This is mostly handy if you want to have a quick user experience (so your users don’t necessarily need to wait for all the encoding to complete),
-but you do want to let users know about some types of errors that can be caught early on, like file format issues.
+When set to `true`, the Transloadit plugin waits for Transloadit’s backend to
+extract metadata from all the uploaded files. This is mostly handy if you want
+to have a quick user experience (so your users don’t necessarily need to wait
+for all the encoding to complete), but you do want to let users know about some
+types of errors that can be caught early on, like file format issues.
 
-You you can listen for the [`transloadit:upload`](#transloaditupload) event when this or `waitForEncoding` is enabled.
+You you can listen for the [`transloadit:upload`](#transloaditupload) event when
+this or `waitForEncoding` is enabled.
 
 #### `importFromUploadURLs`
 
-Allow another plugin to upload files, and then import those files into the Transloadit Assembly (`boolean`, default: `false`).
+Allow another plugin to upload files, and then import those files into the
+Transloadit Assembly (`boolean`, default: `false`).
 
-When enabling this option, Transloadit will _not_ configure the Tus plugin to upload to Transloadit.
-Instead, a separate upload plugin must be used.
-Once the upload completes, the Transloadit plugin adds the uploaded file to the Assembly.
+When enabling this option, Transloadit will _not_ configure the Tus plugin to
+upload to Transloadit. Instead, a separate upload plugin must be used. Once the
+upload completes, the Transloadit plugin adds the uploaded file to the Assembly.
 
 For example, to upload files to an S3 bucket and then transcode them:
 
@@ -324,20 +378,25 @@ uppy.use(Transloadit, {
 });
 ```
 
-Tranloadit will download the files and expose them to your Template as `:original`, as if they were directly uploaded from the Uppy client.  
+Tranloadit will download the files and expose them to your Template as
+`:original`, as if they were directly uploaded from the Uppy client.  
 :::note
-For this to work, the upload plugin must assign a publically accessible `uploadURL` property to the uploaded file object.
-The Tus and S3 plugins both do this automatically.
-For the XHRUpload plugin, you may have to specify a custom `getResponseData` function.
+
+For this to work, the upload plugin must assign a publically accessible
+`uploadURL` property to the uploaded file object. The Tus and S3 plugins both do
+this automatically. For the XHRUpload plugin, you may have to specify a custom
+`getResponseData` function.
+
 :::
 
 #### `alwaysRunAssembly`
 
-Always create and run an Assembly when `uppy.upload()` is called, even if no files were selected (`boolean`, default: `false`).
+Always create and run an Assembly when `uppy.upload()` is called, even if no
+files were selected (`boolean`, default: `false`).
 
-This allows running Assemblies that do not receive files,
-but instead use a robot like [`/s3/import`](https://transloadit.com/docs/transcoding/#s3-import) to download
-the files from elsewhere, for example, for a bulk transcoding job.
+This allows running Assemblies that do not receive files, but instead use a
+robot like [`/s3/import`](https://transloadit.com/docs/transcoding/#s3-import)
+to download the files from elsewhere, for example, for a bulk transcoding job.
 
 #### `locale`
 
@@ -358,21 +417,25 @@ export default {
 <details>
   <summary>Deprecated options</summary>
 
-These options have been deprecated in favor of [`assemblyOptions`](#assemblyoptions),
-which we now recommend for all use cases.
-You can still use these options, but they will be removed in the next major version.
+These options have been deprecated in favor of
+[`assemblyOptions`](#assemblyoptions), which we now recommend for all use cases.
+You can still use these options, but they will be removed in the next major
+version.
 
 #### `getAssemblyOptions`
 
-This function behaves the same as passing a function to [`assemblyOptions`](assemblyoptions).
+This function behaves the same as passing a function to
+[`assemblyOptions`](assemblyoptions).
 
 #### `params`
 
-The Assembly parameters to use for the upload (`object`, default: `null`)
-See the Transloadit documentation on [Assembly Instructions](https://transloadit.com/docs/#14-assembly-instructions) for further information.
+The Assembly parameters to use for the upload (`object`, default: `null`) See
+the Transloadit documentation on
+[Assembly Instructions](https://transloadit.com/docs/#14-assembly-instructions)
+for further information.
 
-The `auth.key` Assembly parameter is required.
-You can also use the `steps` or `template_id` options here as described in the Transloadit documentation.
+The `auth.key` Assembly parameter is required. You can also use the `steps` or
+`template_id` options here as described in the Transloadit documentation.
 
 ```js
 uppy.use(Transloadit, {
@@ -394,17 +457,20 @@ uppy.use(Transloadit, {
 
 #### `signature`
 
-An optional signature for the Assembly parameters.
-See the Transloadit documentation on [Signature Authentication](https://transloadit.com/docs/#26-signature-authentication) for further information.
+An optional signature for the Assembly parameters. See the Transloadit
+documentation on
+[Signature Authentication](https://transloadit.com/docs/#26-signature-authentication)
+for further information.
 
-If a `signature` is provided, `params` should be a JSON string instead of a JavaScript object,
-as otherwise the generated JSON in the browser may be different from the JSON string that was used to generate the signature.
+If a `signature` is provided, `params` should be a JSON string instead of a
+JavaScript object, as otherwise the generated JSON in the browser may be
+different from the JSON string that was used to generate the signature.
 
 #### `fields`
 
-An object of form fields to send along to the Assembly.
-Keys are field names, and values are field values.
-See also the Transloadit documentation on [Form Fields In Instructions](https://transloadit.com/docs/#23-form-fields-in-instructions).
+An object of form fields to send along to the Assembly. Keys are field names,
+and values are field values. See also the Transloadit documentation on
+[Form Fields In Instructions](https://transloadit.com/docs/#23-form-fields-in-instructions).
 
 ```js
 uppy.use(Transloadit, {
@@ -415,12 +481,14 @@ uppy.use(Transloadit, {
 });
 ```
 
-You can also pass an array of field names to send global or file metadata along to the Assembly.
-Global metadata is set using the [`meta` option](/docs/uppy/#meta) in the Uppy constructor,
-or using the [`setMeta` method](/docs/uppy/#uppy-setMeta-data).
-File metadata is set using the [`setFileMeta`](/docs/uppy/#uppy-setFileMeta-fileID-data) method.
-The [Form](/docs/form) plugin also sets global metadata based on the values of `<input />`s in the form,
-providing a handy way to use values from HTML form fields:
+You can also pass an array of field names to send global or file metadata along
+to the Assembly. Global metadata is set using the
+[`meta` option](/docs/uppy/#meta) in the Uppy constructor, or using the
+[`setMeta` method](/docs/uppy/#uppy-setMeta-data). File metadata is set using
+the [`setFileMeta`](/docs/uppy/#uppy-setFileMeta-fileID-data) method. The
+[Form](/docs/form) plugin also sets global metadata based on the values of
+`<input />`s in the form, providing a handy way to use values from HTML form
+fields:
 
 ```js
 uppy.use(Form, { target: 'form#upload-form', getMetaFromForm: true });
@@ -432,7 +500,8 @@ uppy.use(Transloadit, {
 });
 ```
 
-Form fields can also be computed dynamically using custom logic, by using the [`getAssemblyOptions(file)`](/docs/transloadit/#getAssemblyOptions-file) option.
+Form fields can also be computed dynamically using custom logic, by using the
+[`getAssemblyOptions(file)`](/docs/transloadit/#getAssemblyOptions-file) option.
 
 </details>
 
@@ -440,7 +509,8 @@ Form fields can also be computed dynamically using custom logic, by using the [`
 
 #### `COMPANION_URL`
 
-The main endpoint for Transloadit’s hosted companions. You can use this constant in remote provider options, like so:
+The main endpoint for Transloadit’s hosted companions. You can use this constant
+in remote provider options, like so:
 
 ```js
 import Dropbox from '@uppy/dropbox';
@@ -451,11 +521,13 @@ uppy.use(Dropbox, {
 });
 ```
 
-When using `COMPANION_URL`, you should also configure [`companionAllowedHosts`](#companion_allowed_hosts).
+When using `COMPANION_URL`, you should also configure
+[`companionAllowedHosts`](#companion_allowed_hosts).
 
-The value of this constant is `https://api2.transloadit.com/companion`.
-If you are using a custom [`service`](#service) option, you should also set a custom host option in your provider plugins,
-by taking a Transloadit API url and appending `/companion`:
+The value of this constant is `https://api2.transloadit.com/companion`. If you
+are using a custom [`service`](#service) option, you should also set a custom
+host option in your provider plugins, by taking a Transloadit API url and
+appending `/companion`:
 
 ```js
 uppy.use(Dropbox, {
@@ -465,10 +537,10 @@ uppy.use(Dropbox, {
 
 #### `COMPANION_ALLOWED_HOSTS`
 
-A RegExp pattern matching Transloadit’s hosted companion endpoints.
-The pattern is used in remote provider `companionAllowedHosts` options,
-to make sure that third party authentication messages cannot be faked by an attacker’s page
-but can only originate from Transloadit’s servers.
+A RegExp pattern matching Transloadit’s hosted companion endpoints. The pattern
+is used in remote provider `companionAllowedHosts` options, to make sure that
+third party authentication messages cannot be faked by an attacker’s page but
+can only originate from Transloadit’s servers.
 
 Use it whenever you use `companionUrl: COMPANION_URL`, like so:
 
@@ -481,10 +553,11 @@ uppy.use(Dropbox, {
 });
 ```
 
-The value of this constant covers _all_ Transloadit’s Companion servers,
-so it does not need to be changed if you are using a custom [`service`](#service) option.
-But, if you are not using the Transloadit Companion servers at `*.transloadit.com`,
-make sure to set the `companionAllowedHosts` option to something that matches what you do use.
+The value of this constant covers _all_ Transloadit’s Companion servers, so it
+does not need to be changed if you are using a custom [`service`](#service)
+option. But, if you are not using the Transloadit Companion servers at
+`*.transloadit.com`, make sure to set the `companionAllowedHosts` option to
+something that matches what you do use.
 
 ### Events
 
@@ -509,12 +582,14 @@ uppy.on('transloadit:assembly-created', (assembly, fileIDs) => {
 
 #### `transloadit:upload`
 
-Fired when Transloadit has received an upload. Requires [`waitForMetadata`](#waitformetadata) to be set.
+Fired when Transloadit has received an upload. Requires
+[`waitForMetadata`](#waitformetadata) to be set.
 
 **Parameters**
 
 - `file` - The Transloadit file object that was uploaded.
-- `assembly` - The [Assembly Status][assembly-status] of the Assembly to which the file was uploaded.
+- `assembly` - The [Assembly Status][assembly-status] of the Assembly to which
+  the file was uploaded.
 
 #### `transloadit:assembly-executing`
 
@@ -522,19 +597,23 @@ Fired when Transloadit has received all uploads, and is executing the Assembly.
 
 **Parameters**
 
-- `assembly` - The [Assembly Status](https://transloadit.com/docs/api/#assembly-status-response) of the Assembly that is executing.
+- `assembly` - The
+  [Assembly Status](https://transloadit.com/docs/api/#assembly-status-response)
+  of the Assembly that is executing.
 
 #### `transloadit:result`
 
-Fired when a result came in from an Assembly. Requires [`waitForEncoding`](#waitforencoding) to be set.
+Fired when a result came in from an Assembly. Requires
+[`waitForEncoding`](#waitforencoding) to be set.
 
 **Parameters**
 
 - `stepName` - The name of the Assembly step that generated this result.
-- `result` - The result object from Transloadit.
-  This result object has one more property, namely `localId`.
-  This is the ID of the file in Uppy’s local state, and can be used with `uppy.getFile(id)`.
-- `assembly` - The [Assembly Status][assembly-status] of the Assembly that generated this result.
+- `result` - The result object from Transloadit. This result object has one more
+  property, namely `localId`. This is the ID of the file in Uppy’s local state,
+  and can be used with `uppy.getFile(id)`.
+- `assembly` - The [Assembly Status][assembly-status] of the Assembly that
+  generated this result.
 
 ```js
 uppy.on('transloadit:result', (stepName, result) => {
@@ -550,11 +629,13 @@ uppy.on('transloadit:result', (stepName, result) => {
 
 #### `transloadit:complete`
 
-Fired when an Assembly completed. Requires [`waitForEncoding`](#waitForEncoding) to be set.
+Fired when an Assembly completed. Requires [`waitForEncoding`](#waitForEncoding)
+to be set.
 
 **Parameters**
 
-- `assembly` - The final [Assembly Status][assembly-status] of the completed Assembly.
+- `assembly` - The final [Assembly Status][assembly-status] of the completed
+  Assembly.
 
 ```js
 uppy.on('transloadit:complete', (assembly) => {
@@ -567,7 +648,8 @@ uppy.on('transloadit:complete', (assembly) => {
 
 ### Accessing the assembly when an error occurred
 
-If an error occurs when an Assembly has already started, you can find the Assembly Status on the error object’s `assembly` property.
+If an error occurs when an Assembly has already started, you can find the
+Assembly Status on the error object’s `assembly` property.
 
 ```js
 uppy.on('error', (error) => {
@@ -580,11 +662,12 @@ uppy.on('error', (error) => {
 
 ### Assembly behavior when Uppy is closed
 
-When integrating `@uppy/transloadit` with `@uppy/dashboard`,
-closing the dashboard will result in continuing assemblies on the server.
-When the user manually cancels the upload any running assemblies will be cancelled.
+When integrating `@uppy/transloadit` with `@uppy/dashboard`, closing the
+dashboard will result in continuing assemblies on the server. When the user
+manually cancels the upload any running assemblies will be cancelled.
 
 [assembly-status]: https://transloadit.com/docs/api/#assembly-status-response
-[template-credentials]: https://transloadit.com/docs/#how-to-create-template-credentials
+[template-credentials]:
+	https://transloadit.com/docs/#how-to-create-template-credentials
 [transloadit-services]: https://transloadit.com/services/
 [transloadit-concepts]: https://transloadit.com/docs/getting-started/concepts/

--- a/docs/uploader/tus.mdx
+++ b/docs/uploader/tus.mdx
@@ -8,25 +8,31 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # Tus
 
-The `@uppy/tus` plugin brings resumable file uploading with [Tus](http://tus.io) to Uppy by wrapping the [`tus-js-client`][].
+The `@uppy/tus` plugin brings resumable file uploading with [Tus](http://tus.io)
+to Uppy by wrapping the [`tus-js-client`][].
 
 ## When should I use it?
 
 :::tip
-Not sure which uploader is best for you? Read “[Choosing the uploader you need](/docs/guides/choosing-uploader)”.
+
+Not sure which uploader is best for you? Read
+“[Choosing the uploader you need](/docs/guides/choosing-uploader)”.
+
 :::
 
-[Tus][tus] is an open protocol for resumable uploads built on HTTP.
-This means accidentally closing your tab or losing connection let’s you continue, for instance, your 10GB upload
-instead of starting all over.
+[Tus][tus] is an open protocol for resumable uploads built on HTTP. This means
+accidentally closing your tab or losing connection let’s you continue, for
+instance, your 10GB upload instead of starting all over.
 
-Tus supports any language, any platform, and any network.
-It requires a client and server integration to work.
-You can checkout the client and server [implementations][] to find the server in your preferred language.
-You can store files on the Tus server itself, but you can also use service integrations (such as S3) to store files externally.
-If you don’t want to host your own server, see “[Are there hosted Tus servers?](#are-there-hosted-tus-servers)”.
+Tus supports any language, any platform, and any network. It requires a client
+and server integration to work. You can checkout the client and server
+[implementations][] to find the server in your preferred language. You can store
+files on the Tus server itself, but you can also use service integrations (such
+as S3) to store files externally. If you don’t want to host your own server, see
+“[Are there hosted Tus servers?](#are-there-hosted-tus-servers)”.
 
-If you want reliable, resumable uploads: use `@uppy/tus` to connect to your Tus server in a few lines of code.
+If you want reliable, resumable uploads: use `@uppy/tus` to connect to your Tus
+server in a few lines of code.
 
 ## Install
 
@@ -79,10 +85,15 @@ new Uppy()
 ### Options
 
 :::info
-All options are passed to `tus-js-client` and we document the ones here that are required, added, or changed.
-This means you can also pass functions like [`onAfterResponse`](https://github.com/tus/tus-js-client/blob/master/docs/api.md#onafterresponse).
 
-We recommended taking a look at the [API reference](https://github.com/tus/tus-js-client/blob/master/docs/api.md) from `tus-js-client` to know what is supported.
+All options are passed to `tus-js-client` and we document the ones here that are
+required, added, or changed. This means you can also pass functions like
+[`onAfterResponse`](https://github.com/tus/tus-js-client/blob/master/docs/api.md#onafterresponse).
+
+We recommended taking a look at the
+[API reference](https://github.com/tus/tus-js-client/blob/master/docs/api.md)
+from `tus-js-client` to know what is supported.
+
 :::
 
 #### `id`
@@ -95,7 +106,8 @@ URL of the tus server (`string`, default: `null`).
 
 #### `headers`
 
-An object or function returning an object with HTTP headers to send to send along requests (`object | function`, default: `null`).
+An object or function returning an object with HTTP headers to send to send
+along requests (`object | function`, default: `null`).
 
 Keys are header names, values are header values.
 
@@ -105,8 +117,9 @@ const headers = {
 };
 ```
 
-Header values can also be derived from file data by providing a function.
-The function receives an [Uppy file][] and must return an object where the keys are header names, and values are header values.
+Header values can also be derived from file data by providing a function. The
+function receives an [Uppy file][] and must return an object where the keys are
+header names, and values are header values.
 
 ```js
 const headers = (file) => {
@@ -119,39 +132,55 @@ const headers = (file) => {
 
 #### `chunkSize`
 
-A number indicating the maximum size of a `PATCH` request body in bytes (`number`, default: `Infinity`).
+A number indicating the maximum size of a `PATCH` request body in bytes
+(`number`, default: `Infinity`).
 
 :::caution
-Do not set this value unless you are forced to.
-The two valid reasons are described in the [`tus-js-client` docs](https://github.com/tus/tus-js-client/blob/master/docs/api.md#chunksize).
+
+Do not set this value unless you are forced to. The two valid reasons are
+described in the
+[`tus-js-client` docs](https://github.com/tus/tus-js-client/blob/master/docs/api.md#chunksize).
+
 :::
 
 #### `withCredentials`
 
-Configure the requests to send Cookies using the [`xhr.withCredentials`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials) property (`boolean`, default: `false`).
+Configure the requests to send Cookies using the
+[`xhr.withCredentials`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials)
+property (`boolean`, default: `false`).
 
 The remote server must accept CORS and credentials.
 
 #### `retryDelays`
 
-When uploading a chunk fails, automatically try again after the defined millisecond intervals (`Array<number>`, default: `[0, 1000, 3000, 5000]`).
+When uploading a chunk fails, automatically try again after the defined
+millisecond intervals (`Array<number>`, default: `[0, 1000, 3000, 5000]`).
 
-By default, we first retry instantly; if that fails, we retry after 1 second; if that fails, we retry after 3 seconds, etc.
+By default, we first retry instantly; if that fails, we retry after 1 second; if
+that fails, we retry after 3 seconds, etc.
 
-Set to `null` to disable automatic retries, and fail instantly if any chunk fails to upload.
+Set to `null` to disable automatic retries, and fail instantly if any chunk
+fails to upload.
 
 #### `onBeforeRequest(req, file)`
 
-Behaves like the [`onBeforeRequest`](https://github.com/tus/tus-js-client/blob/master/docs/api.md#onbeforerequest) function from `tus-js-client` but with the added `file` argument.
+Behaves like the
+[`onBeforeRequest`](https://github.com/tus/tus-js-client/blob/master/docs/api.md#onbeforerequest)
+function from `tus-js-client` but with the added `file` argument.
 
 #### `onShouldRetry: (err, retryAttempt, options, next)`
 
-When an upload fails `onShouldRetry` is called with the error and the default retry logic as the last argument (`function`).
+When an upload fails `onShouldRetry` is called with the error and the default
+retry logic as the last argument (`function`).
 
-The default retry logic is an [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff) algorithm triggered on HTTP 429 (Too Many Requests) errors.
-Meaning if your server (or proxy) returns HTTP 429 because it’s being overloaded, @uppy/tus will find the ideal sweet spot to keep uploading without overloading.
+The default retry logic is an
+[exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff)
+algorithm triggered on HTTP 429 (Too Many Requests) errors. Meaning if your
+server (or proxy) returns HTTP 429 because it’s being overloaded, @uppy/tus will
+find the ideal sweet spot to keep uploading without overloading.
 
-If you want to extend this functionality, for instance to retry on unauthorized requests (to retrieve a new authentication token):
+If you want to extend this functionality, for instance to retry on unauthorized
+requests (to retrieve a new authentication token):
 
 ```js
 import Uppy from '@uppy/core';
@@ -178,7 +207,10 @@ new Uppy().use(Tus, {
 
 #### `allowedMetaFields`
 
-Pass an array of field names to limit the metadata fields that will be added to uploads as [Tus Metadata](https://tus.io/protocols/resumable-upload.html#upload-metadata) (`Array`, default: `null`).
+Pass an array of field names to limit the metadata fields that will be added to
+uploads as
+[Tus Metadata](https://tus.io/protocols/resumable-upload.html#upload-metadata)
+(`Array`, default: `null`).
 
 - Set this to `['name']` to only send the `name` field.
 - Set this to `null` (the default) to send _all_ metadata fields.
@@ -193,13 +225,17 @@ Setting this to `0` means no limit on concurrent uploads (not recommend)
 ## Frequently Asked Questions
 
 :::info
-The Tus website has extensive [FAQ section](https://tus.io/faq.html), we recommend taking a look there as well if something is unclear.
+
+The Tus website has extensive [FAQ section](https://tus.io/faq.html), we
+recommend taking a look there as well if something is unclear.
+
 :::
 
 ### How is file meta data stored?
 
-Tus uses unique identifers for the file names to prevent naming collisions.
-To still keep the meta data in place, Tus also uploads an extra `.info` file with the original file name and other meta data:
+Tus uses unique identifers for the file names to prevent naming collisions. To
+still keep the meta data in place, Tus also uploads an extra `.info` file with
+the original file name and other meta data:
 
 ```json
 {
@@ -224,36 +260,44 @@ To still keep the meta data in place, Tus also uploads an extra `.info` file wit
 
 ### How do I change files before sending them?
 
-If you want to change the file names, you want to do that in [`onBeforeFileAdded`](/docs/uppy-core#onbeforefileaddedfile-files).
+If you want to change the file names, you want to do that in
+[`onBeforeFileAdded`](/docs/uppy-core#onbeforefileaddedfile-files).
 
-If you want to send extra headers with the request, use [`headers`](#headers) or [`onBeforeRequest`](#onbeforerequestreq-file).
+If you want to send extra headers with the request, use [`headers`](#headers) or
+[`onBeforeRequest`](#onbeforerequestreq-file).
 
 ### How do I change (or move) files after sending them?
 
-If you want to preserve files names, extract meta data, or move files to a different place you generally can with hooks or events.
-It depends on the Tus server you use how it’s done exactly. [`tusd`][], for instance, exposes [hooks](https://github.com/tus/tusd/blob/master/docs/hooks.md)
-and [`tus-node-server`](https://github.com/tus/tus-node-server) has [events](https://github.com/tus/tus-node-server#events).
+If you want to preserve files names, extract meta data, or move files to a
+different place you generally can with hooks or events. It depends on the Tus
+server you use how it’s done exactly. [`tusd`][], for instance, exposes
+[hooks](https://github.com/tus/tusd/blob/master/docs/hooks.md) and
+[`tus-node-server`](https://github.com/tus/tus-node-server) has
+[events](https://github.com/tus/tus-node-server#events).
 
 ### Which server do you recommend?
 
-[Transloadit](https://transloadit.com) runs [`tusd`][] in production, where it serves millions of requests globally.
-Therefor we recommend `tusd` as battle-tested from our side, but other companies have had success with other [implementations][] so it depends on your needs.
+[Transloadit](https://transloadit.com) runs [`tusd`][] in production, where it
+serves millions of requests globally. Therefor we recommend `tusd` as
+battle-tested from our side, but other companies have had success with other
+[implementations][] so it depends on your needs.
 
 ### Are there hosted Tus servers?
 
-All [Transloadit plans](https://transloadit.com/pricing) come with a hosted [`tusd`][] server.
-You don’t have to do anything to leverage it, using [`@uppy/transloadit`](/docs/upload-strategies/transloadit) automatically
-uses Tus under the hood.
+All [Transloadit plans](https://transloadit.com/pricing) come with a hosted
+[`tusd`][] server. You don’t have to do anything to leverage it, using
+[`@uppy/transloadit`](/docs/upload-strategies/transloadit) automatically uses
+Tus under the hood.
 
 ### Why Tus instead of directly uploading to AWS S3?
 
-First: reliable, resumable uploads.
-This means accidentally closing your tab or losing connection let’s you continue, for instance, your 10GB upload
-instead of starting all over.
+First: reliable, resumable uploads. This means accidentally closing your tab or
+losing connection let’s you continue, for instance, your 10GB upload instead of
+starting all over.
 
-Tus is also efficient with lots of files (such as 8K) and large files.
-Uploading to AWS S3 directly from the client also introduces quite a bit of overhead,
-as more requests are needed for the flow to work.
+Tus is also efficient with lots of files (such as 8K) and large files. Uploading
+to AWS S3 directly from the client also introduces quite a bit of overhead, as
+more requests are needed for the flow to work.
 
 [`tus-js-client`]: https://github.com/tus/tus-js-client
 [uppy file]: /docs/uppy-core#working-with-uppy-files

--- a/docs/uploader/xhr.mdx
+++ b/docs/uploader/xhr.mdx
@@ -13,12 +13,17 @@ The `@uppy/xhr-upload` plugin is for regular uploads to a HTTP server.
 ## When should I use it?
 
 :::tip
-Not sure which uploader is best for you? Read “[Choosing the uploader you need](/docs/guides/choosing-uploader)”.
+
+Not sure which uploader is best for you? Read
+“[Choosing the uploader you need](/docs/guides/choosing-uploader)”.
+
 :::
 
-When you have an existing HTTP server and you don’t need Transloadit services or want to run a [tus][] server.
-Note that it’s still possible to use [tus][] without running an extra server by integrating tus into your existing one.
-For instance, if you have a Node.js server (or server-side framework like Next.js) you could integrate [tus-node-server][].
+When you have an existing HTTP server and you don’t need Transloadit services or
+want to run a [tus][] server. Note that it’s still possible to use [tus][]
+without running an extra server by integrating tus into your existing one. For
+instance, if you have a Node.js server (or server-side framework like Next.js)
+you could integrate [tus-node-server][].
 
 ## Install
 
@@ -80,37 +85,42 @@ URL of the tus server (`string`, default: `null`).
 
 #### `method`
 
-Configures which HTTP method to use for the upload (`string`, default: `'post'`).
+Configures which HTTP method to use for the upload (`string`, default:
+`'post'`).
 
 #### `formData`
 
-Configures whether to use a multipart form upload, using [FormData][] (`boolean`, default: `true`).
+Configures whether to use a multipart form upload, using [FormData][]
+(`boolean`, default: `true`).
 
-This works similarly to using a `<form>` element with an `<input type="file">` for uploads.
-When set to `true`, file metadata is also sent to the endpoint as separate form fields.
-When set to `false`, only the file contents are sent.
+This works similarly to using a `<form>` element with an `<input type="file">`
+for uploads. When set to `true`, file metadata is also sent to the endpoint as
+separate form fields. When set to `false`, only the file contents are sent.
 
 #### `fieldName`
 
 When [`formData`](#formData-true) is set to true, this is used as the form field
 name for the file to be uploaded.
 
-It defaults to `'files[]'` if `bundle` option is set to `true`, otherwise it defaults to `'file'`.
+It defaults to `'files[]'` if `bundle` option is set to `true`, otherwise it
+defaults to `'file'`.
 
 #### `allowedMetaFields`
 
-Pass an array of field names to limit the metadata fields that will be added to upload.
+Pass an array of field names to limit the metadata fields that will be added to
+upload.
 
 - Set this to an empty array `[]` to not send any fields.
 - Set this to `['name']` to only send the `name` field.
 - Set this to `null` (the default) to send _all_ metadata fields.
 
-If the [`formData`](#formData-true) option is set to false, `metaFields` is ignored.
+If the [`formData`](#formData-true) option is set to false, `metaFields` is
+ignored.
 
 #### `headers`
 
-An object containing HTTP headers to use for the upload request.
-Keys are header names, values are header values.
+An object containing HTTP headers to use for the upload request. Keys are header
+names, values are header values.
 
 ```js
 const headers = {
@@ -118,8 +128,9 @@ const headers = {
 };
 ```
 
-Header values can also be derived from file data by providing a function.
-The function receives an [Uppy file][] and must return an object where the keys are header names, and values are header values.
+Header values can also be derived from file data by providing a function. The
+function receives an [Uppy file][] and must return an object where the keys are
+header names, and values are header values.
 
 ```js
 const headers = (file) => {
@@ -131,7 +142,9 @@ const headers = (file) => {
 ```
 
 :::note
+
 The function syntax is not available when [`bundle`](#bundle) is set to `true`.
+
 :::
 
 #### `bundle`
@@ -141,16 +154,20 @@ Send all files in a single multipart request (`boolean`, default: `false`).
 All files will be appended to the provided `fieldName` field in the request.
 
 :::caution
+
 When `bundle` is set to `true`:
 
 - [`formData`](#formData-true) must also be set to `true`.
-- Uppy won’t be able to bundle remote files (such as Google Drive) and will throw an error in this case.
-- Only [global uppy metadata](/docs/uppy-core/#meta) is sent to the endpoint. Individual per-file metadata is ignored.
+- Uppy won’t be able to bundle remote files (such as Google Drive) and will
+  throw an error in this case.
+- Only [global uppy metadata](/docs/uppy-core/#meta) is sent to the endpoint.
+  Individual per-file metadata is ignored.
 
 :::
 
-To upload files on different fields, use [`uppy.setFileState()`](/docs/uppy#uppy-setFileState-fileID-state) to set
-the `xhrUpload.fieldName` property on the file:
+To upload files on different fields, use
+[`uppy.setFileState()`](/docs/uppy#uppy-setFileState-fileID-state) to set the
+`xhrUpload.fieldName` property on the file:
 
 ```js
 uppy.setFileState(fileID, {
@@ -160,11 +177,16 @@ uppy.setFileState(fileID, {
 
 #### `validateStatus`
 
-Check if the response was successful (`function`, default: `(status, responseText, response) => boolean`).
+Check if the response was successful (`function`, default:
+`(status, responseText, response) => boolean`).
 
 - By default, responses with a 2xx HTTP status code are considered successful.
-- When `true`, [`getResponseData()`](#getResponseData-responseText-response) will be called and the upload will be marked as successful.
-- When `false`, both [`getResponseData()`](#getResponseData-responseText-response) and [`getResponseError()`](#getResponseError-responseText-response) will be called and the upload will be marked as unsuccessful.
+- When `true`, [`getResponseData()`](#getResponseData-responseText-response)
+  will be called and the upload will be marked as successful.
+- When `false`, both
+  [`getResponseData()`](#getResponseData-responseText-response) and
+  [`getResponseError()`](#getResponseError-responseText-response) will be called
+  and the upload will be marked as unsuccessful.
 
 ##### Parameters
 
@@ -173,19 +195,24 @@ Check if the response was successful (`function`, default: `(status, responseTex
 - `response` is the [XMLHttpRequest][] object.
 
 :::note
-This option is only used for **local** uploads.
-Uploads from remote providers like Google Drive or Instagram do not support this and will always use the default.
+
+This option is only used for **local** uploads. Uploads from remote providers
+like Google Drive or Instagram do not support this and will always use the
+default.
+
 :::
 
 #### `getResponseData`
 
-Extract the response data from the successful upload (`function`, default: `(responseText, response) => void`).
+Extract the response data from the successful upload (`function`, default:
+`(responseText, response) => void`).
 
 - `responseText` is the XHR endpoint response as a string.
 - `response` is the [XMLHttpRequest][] object.
 
-JSON is handled automatically, so you should only use this if the endpoint responds with a different format.
-For example, an endpoint that responds with an XML document:
+JSON is handled automatically, so you should only use this if the endpoint
+responds with a different format. For example, an endpoint that responds with an
+XML document:
 
 ```js
 function getResponseData(responseText, response) {
@@ -198,21 +225,28 @@ function getResponseData(responseText, response) {
 ```
 
 :::note
-This response data will be available on the file’s `.response` property and will be
-emitted in the [`upload-success`][uppy.upload-success] event.
+
+This response data will be available on the file’s `.response` property and will
+be emitted in the [`upload-success`][uppy.upload-success] event.
+
 :::
 
 :::note
-When uploading files from remote providers such as Dropbox or Instagram, Companion sends upload response data to the client.
-This is made available in the `getResponseData()` function as well.
-The `response` object from Companion has some properties named after their [XMLHttpRequest][] counterparts.
+
+When uploading files from remote providers such as Dropbox or Instagram,
+Companion sends upload response data to the client. This is made available in
+the `getResponseData()` function as well. The `response` object from Companion
+has some properties named after their [XMLHttpRequest][] counterparts.
+
 :::
 
 #### `getResponseError`
 
-Extract the error from the failed upload (`function`, default: `(responseText, response) => void`).
+Extract the error from the failed upload (`function`, default:
+`(responseText, response) => void`).
 
-For example, if the endpoint responds with a JSON object containing a `{ message }` property, this would show that message to the user:
+For example, if the endpoint responds with a JSON object containing a
+`{ message }` property, this would show that message to the user:
 
 ```js
 function getResponseError(responseText, response) {
@@ -222,16 +256,18 @@ function getResponseError(responseText, response) {
 
 #### `responseUrlFieldName`
 
-The field name containing the location of the uploaded file (`string`, default: `'url'`).
+The field name containing the location of the uploaded file (`string`, default:
+`'url'`).
 
 This is returned by [`getResponseData()`](#getResponseData).
 
 #### `timeout: 30 * 1000`
 
-Abort the connection if no upload progress events have been received for this milliseconds amount (`number`, default: `30_000`).
+Abort the connection if no upload progress events have been received for this
+milliseconds amount (`number`, default: `30_000`).
 
-Note that unlike the [`XMLHttpRequest.timeout`][xhr.timeout] property,
-this is a timer between progress events: the total upload can take longer than this value.
+Note that unlike the [`XMLHttpRequest.timeout`][xhr.timeout] property, this is a
+timer between progress events: the total upload can take longer than this value.
 Set to `0` to disable this check.
 
 #### `limit`
@@ -240,16 +276,19 @@ The maximum amount of files to upload in parallel (`number`, default: `5`).
 
 #### `responseType`
 
-The response type expected from the server, determining how the `xhr.response` property should be filled (`string`, default: `'text'`).
+The response type expected from the server, determining how the `xhr.response`
+property should be filled (`string`, default: `'text'`).
 
-The `xhr.response` property can be accessed in a custom [`getResponseData()`](#getResponseData-responseText-response) callback.
-This option sets the [`XMLHttpRequest.responseType`][xhr.responsetype] property.
-Only `''`, `'text'`, `'arraybuffer'`, `'blob'` and `'document'` are widely supported by browsers,
-so it’s recommended to use one of those.
+The `xhr.response` property can be accessed in a custom
+[`getResponseData()`](#getResponseData-responseText-response) callback. This
+option sets the [`XMLHttpRequest.responseType`][xhr.responsetype] property. Only
+`''`, `'text'`, `'arraybuffer'`, `'blob'` and `'document'` are widely supported
+by browsers, so it’s recommended to use one of those.
 
 #### `withCredentials`
 
-Indicates whether cross-site Access-Control requests should be made using credentials (`boolean`, default: `false`).
+Indicates whether cross-site Access-Control requests should be made using
+credentials (`boolean`, default: `false`).
 
 #### `locale: {}`
 
@@ -266,13 +305,15 @@ export default {
 
 ### How to send along meta data with the upload?
 
-When using XHRUpload with [`formData: true`](#formData-true),
-file metadata is sent along with each upload request.
-You can set metadata for a file using [`uppy.setFileMeta(fileID, data)`](/docs/uppy#uppy-setFileMeta-fileID-data),
-or for all files simultaneously using [`uppy.setMeta(data)`](/docs/uppy#uppy-setMeta-data).
+When using XHRUpload with [`formData: true`](#formData-true), file metadata is
+sent along with each upload request. You can set metadata for a file using
+[`uppy.setFileMeta(fileID, data)`](/docs/uppy#uppy-setFileMeta-fileID-data), or
+for all files simultaneously using
+[`uppy.setMeta(data)`](/docs/uppy#uppy-setMeta-data).
 
-It may be useful to set metadata depending on some file properties, such as the size.
-You can use the [`file-added`](/docs/uppy/#file-added) event and the [`uppy.setFileMeta(fileID, data)`](/docs/uppy#uppy-setFileMeta-fileID-data)
+It may be useful to set metadata depending on some file properties, such as the
+size. You can use the [`file-added`](/docs/uppy/#file-added) event and the
+[`uppy.setFileMeta(fileID, data)`](/docs/uppy#uppy-setFileMeta-fileID-data)
 method to do this:
 
 ```js
@@ -283,9 +324,13 @@ uppy.on('file-added', (file) => {
 });
 ```
 
-Now, a form field named `size` will be sent along to the [`endpoint`](#endpoint-39-39) once the upload starts.
+Now, a form field named `size` will be sent along to the
+[`endpoint`](#endpoint-39-39) once the upload starts.
 
-By default, all metadata is sent, including Uppy’s default `name` and `type` metadata. If you do not want the `name` and `type` metadata properties to be sent to your upload endpoint, you can use the [`metaFields`](#metaFields-null) option to restrict the field names that should be sent.
+By default, all metadata is sent, including Uppy’s default `name` and `type`
+metadata. If you do not want the `name` and `type` metadata properties to be
+sent to your upload endpoint, you can use the [`metaFields`](#metaFields-null)
+option to restrict the field names that should be sent.
 
 ```js
 uppy.use(XHRUpload, {
@@ -296,11 +341,12 @@ uppy.use(XHRUpload, {
 
 ### How to upload to a PHP server?
 
-The XHRUpload plugin works similarly to a `<form>` upload.
-You can use the `$_FILES` variable on the server to work with uploaded files.
-See the PHP documentation on [Handling file uploads][php.file-upload].
+The XHRUpload plugin works similarly to a `<form>` upload. You can use the
+`$_FILES` variable on the server to work with uploaded files. See the PHP
+documentation on [Handling file uploads][php.file-upload].
 
-The default form field for file uploads is `files[]`, which means you have to access the `$_FILES` array as described in [Uploading many files][php.multiple]:
+The default form field for file uploads is `files[]`, which means you have to
+access the `$_FILES` array as described in [Uploading many files][php.multiple]:
 
 ```php
 <?php
@@ -311,9 +357,13 @@ $file_name = $_POST['name']; // desired name of the file
 move_uploaded_file($file_path, './img/' . basename($file_name)); // save the file in `img/`
 ```
 
-Note how we are using `$_POST['name']` instead of `$my_file['name']`. `$my_file['name']` has the original name of the file on the user’s device. `$_POST['name']` has the `name` metadata value for the uploaded file, which can be edited by the user using the [Dashboard](/docs/dashboard).
+Note how we are using `$_POST['name']` instead of `$my_file['name']`.
+`$my_file['name']` has the original name of the file on the user’s device.
+`$_POST['name']` has the `name` metadata value for the uploaded file, which can
+be edited by the user using the [Dashboard](/docs/dashboard).
 
-Set a custom `fieldName` to make working with the `$_FILES` array a bit less convoluted:
+Set a custom `fieldName` to make working with the `$_FILES` array a bit less
+convoluted:
 
 ```js
 // app.js
@@ -333,12 +383,16 @@ move_uploaded_file($file_path, $_SERVER['DOCUMENT_ROOT'] . '/img/' . basename($f
 ```
 
 [formdata]: https://developer.mozilla.org/en-US/docs/Web/API/FormData
-[xmlhttprequest]: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest
-[xhr.timeout]: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/timeout
-[xhr.responsetype]: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType
+[xmlhttprequest]:
+	https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest
+[xhr.timeout]:
+	https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/timeout
+[xhr.responsetype]:
+	https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType
 [uppy.upload-success]: /docs/uppy/#upload-success
 [uppy file]: /docs/uppy-core#working-with-uppy-files
 [php.file-upload]: https://secure.php.net/manual/en/features.file-upload.php
-[php.multiple]: https://secure.php.net/manual/en/features.file-upload.multiple.php
+[php.multiple]:
+	https://secure.php.net/manual/en/features.file-upload.multiple.php
 [tus-node-server]: https://github.com/tus/tus-node-server
 [tus]: https://tus.io/

--- a/docs/uppy-core.mdx
+++ b/docs/uppy-core.mdx
@@ -9,21 +9,26 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # Uppy core
 
-Uppy can be an uploader and an interface with a lot of features.
-Features can be added incrementally with plugins, but Uppy can be as bare bones as you want it to be.
-Therefor we build Uppy’s heart, `@uppy/core`, as a standalone orchestrator.
-It acts as a state manager, event emitter, and restrictions handler.
+Uppy can be an uploader and an interface with a lot of features. Features can be
+added incrementally with plugins, but Uppy can be as bare bones as you want it
+to be. Therefor we build Uppy’s heart, `@uppy/core`, as a standalone
+orchestrator. It acts as a state manager, event emitter, and restrictions
+handler.
 
 ## When should I use it?
 
-`@uppy/core` is the fundament of the Uppy ecosystem, the orchestrator for all added plugins.
-No matter the uploading experience you’re looking for, it all starts with installing this plugin.
+`@uppy/core` is the fundament of the Uppy ecosystem, the orchestrator for all
+added plugins. No matter the uploading experience you’re looking for, it all
+starts with installing this plugin.
 
-You can use `@uppy/core` and [build your own UI](/docs/guides/building-your-own-ui-with-uppy)
-or go for the [Dashboard](/docs/interfaces/dashboard) integration.
-For an uploading plugin, you can refer to [choosing the uploader you need](/docs/guides/choosing-uploader).
+You can use `@uppy/core` and
+[build your own UI](/docs/guides/building-your-own-ui-with-uppy) or go for the
+[Dashboard](/docs/interfaces/dashboard) integration. For an uploading plugin,
+you can refer to
+[choosing the uploader you need](/docs/guides/choosing-uploader).
 
-If you want to see how it all comes together, checkout the [examples](/examples).
+If you want to see how it all comes together, checkout the
+[examples](/examples).
 
 ## Install
 
@@ -56,14 +61,15 @@ yarn add @uppy/core
 
 ## Use
 
-`@uppy/core` has four exports: `Uppy`, `UIPlugin`, `BasePlugin`, and `debugLogger`.
-The default export is the `Uppy` class.
+`@uppy/core` has four exports: `Uppy`, `UIPlugin`, `BasePlugin`, and
+`debugLogger`. The default export is the `Uppy` class.
 
 ### Working with Uppy files
 
-Uppy keeps files in state with the [`File`][] browser API, but it’s wrapped in an `Object`
-to be able to add more data to it, which we call an Uppy file.
-All these properties can be useful for plugins and side-effects (such as [events](#events)).
+Uppy keeps files in state with the [`File`][] browser API, but it’s wrapped in
+an `Object` to be able to add more data to it, which we call an Uppy file. All
+these properties can be useful for plugins and side-effects (such as
+[events](#events)).
 
 Mutating these properties should be done through [methods](#methods).
 
@@ -72,7 +78,8 @@ Mutating these properties should be done through [methods](#methods).
 
 #### `file.source`
 
-Name of the plugin that was responsible for adding this file. Typically a remote provider plugin like `'GoogleDrive'` or a UI plugin like `'DragDrop'`.
+Name of the plugin that was responsible for adding this file. Typically a remote
+provider plugin like `'GoogleDrive'` or a UI plugin like `'DragDrop'`.
 
 #### `file.id`
 
@@ -88,13 +95,17 @@ Object containing file metadata. Any file metadata should be JSON-serializable.
 
 #### `file.type`
 
-MIME type of the file. This may actually be guessed if a file type was not provided by the user’s browser, so this is a best-effort value and not guaranteed to be correct.
+MIME type of the file. This may actually be guessed if a file type was not
+provided by the user’s browser, so this is a best-effort value and not
+guaranteed to be correct.
 
 #### `file.data`
 
-For local files, this is the actual [`File`][] or [`Blob`][] object representing the file contents.
+For local files, this is the actual [`File`][] or [`Blob`][] object representing
+the file contents.
 
-For files that are imported from remote providers, the file data is not available in the browser.
+For files that are imported from remote providers, the file data is not
+available in the browser.
 
 [`file`]: https://developer.mozilla.org/en-US/docs/Web/API/File
 [`blob`]: https://developer.mozilla.org/en-US/docs/Web/API/Blob
@@ -107,8 +118,11 @@ An object with upload progress data.
 
 - `bytesUploaded` - Number of bytes uploaded so far.
 - `bytesTotal` - Number of bytes that must be uploaded in total.
-- `uploadStarted` - Null if the upload has not started yet. Once started, this property stores a UNIX timestamp. Note that this is only set _after_ preprocessing.
-- `uploadComplete` - Boolean indicating if the upload has completed. Note this does _not_ mean that postprocessing has completed, too.
+- `uploadStarted` - Null if the upload has not started yet. Once started, this
+  property stores a UNIX timestamp. Note that this is only set _after_
+  preprocessing.
+- `uploadComplete` - Boolean indicating if the upload has completed. Note this
+  does _not_ mean that postprocessing has completed, too.
 - `percentage` - Integer percentage between 0 and 100.
 
 #### `file.size`
@@ -149,56 +163,68 @@ const uppy = new Uppy();
 A site-wide unique ID for the instance (`string`, default: `uppy`).
 
 :::note
-If several Uppy instances are being used, for instance, on two different pages, an `id` should be specified.
-This allows Uppy to store information in `localStorage` without colliding with other Uppy instances.
 
-This ID should be persistent across page reloads and navigation—it shouldn’t be a random number
-that is different every time Uppy is loaded.
+If several Uppy instances are being used, for instance, on two different pages,
+an `id` should be specified. This allows Uppy to store information in
+`localStorage` without colliding with other Uppy instances.
+
+This ID should be persistent across page reloads and navigation—it shouldn’t be
+a random number that is different every time Uppy is loaded.
+
 :::
 
 #### `autoProceed`
 
 Upload as soon as files are added (`boolean`, default: `false`).
 
-By default Uppy will wait for an upload button to be pressed in the UI,
-or the `.upload()` method to be called before starting an upload.
-Setting this to `true` will start uploading automatically after the first file is selected
+By default Uppy will wait for an upload button to be pressed in the UI, or the
+`.upload()` method to be called before starting an upload. Setting this to
+`true` will start uploading automatically after the first file is selected
 
 #### `allowMultipleUploadBatches`
 
 Whether to allow several upload batches (`boolean`, default: `true`).
 
-This means several calls to `.upload()`,
-or a user adding more files after already uploading some.
-An upload batch is made up of the files that were added since the earlier `.upload()` call.
+This means several calls to `.upload()`, or a user adding more files after
+already uploading some. An upload batch is made up of the files that were added
+since the earlier `.upload()` call.
 
-With this option set to `true`, users can upload some files, and then add _more_ files and upload those as well.
-A model use case for this is uploading images to a gallery or adding attachments to an email.
+With this option set to `true`, users can upload some files, and then add _more_
+files and upload those as well. A model use case for this is uploading images to
+a gallery or adding attachments to an email.
 
-With this option set to `false`, users can upload some files, and you can listen for the [`'complete'`](#complete)
-event to continue to the next step in your app’s upload flow.
-A typical use case for this is uploading a new profile picture.
-If you are integrating with an existing HTML form, this option gives the closest behaviour to a bare `<input type="file">`.
+With this option set to `false`, users can upload some files, and you can listen
+for the [`'complete'`](#complete) event to continue to the next step in your
+app’s upload flow. A typical use case for this is uploading a new profile
+picture. If you are integrating with an existing HTML form, this option gives
+the closest behaviour to a bare `<input type="file">`.
 
 #### `debug`
 
 Whether to send debugging and warning logs (`boolean`, default: `false`).
 
-Setting this to `true` sets the [`logger`](#logger) to [`debugLogger`](#debuglogger).
+Setting this to `true` sets the [`logger`](#logger) to
+[`debugLogger`](#debuglogger).
 
 #### `logger`
 
-Logger used for [`uppy.log`](#logmessage-type) (`Object`, default: `justErrorsLogger`).
+Logger used for [`uppy.log`](#logmessage-type) (`Object`, default:
+`justErrorsLogger`).
 
-By providing your own `logger`, you can send the debug information to a server, choose to log errors only, etc.
+By providing your own `logger`, you can send the debug information to a server,
+choose to log errors only, etc.
 
 :::note
-Set `logger` to [`debugLogger`](#debuglogger) to get debug info output to the browser console:
+
+Set `logger` to [`debugLogger`](#debuglogger) to get debug info output to the
+browser console:
+
 :::
 
 :::note
-You can also provide your own logger object:
-it should expose `debug`, `warn` and `error` methods, as shown in the examples below.
+
+You can also provide your own logger object: it should expose `debug`, `warn`
+and `error` methods, as shown in the examples below.
 
 Here’s an example of a `logger` that does nothing:
 
@@ -227,27 +253,37 @@ Conditions for restricting an upload (`Object`, default: `{}`).
 | `requiredMetaFields` | `Array<string>` | make keys from the `meta` object in every file required before uploading                                                         |
 
 :::note
-`maxNumberOfFiles` also affects the number of files a user is able to select via the system file dialog
-in UI plugins like `DragDrop`, `FileInput` and `Dashboard`.
-When set to `1`, they will only be able to select a single file.
-When `null` or another number is provided, they will be able to select several files.
+
+`maxNumberOfFiles` also affects the number of files a user is able to select via
+the system file dialog in UI plugins like `DragDrop`, `FileInput` and
+`Dashboard`. When set to `1`, they will only be able to select a single file.
+When `null` or another number is provided, they will be able to select several
+files.
+
 :::
 
 :::note
-`allowedFileTypes` gets passed to the file system dialog via
-the [`<input>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#Limiting_accepted_file_types) accept attribute,
-so only types supported by the browser will work.
+
+`allowedFileTypes` gets passed to the file system dialog via the
+[`<input>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#Limiting_accepted_file_types)
+accept attribute, so only types supported by the browser will work.
+
 :::
 
 :::tip
-If you’d like to force a certain meta field data to be entered before the upload,
-you can [do so using `onBeforeUpload`](https://github.com/transloadit/uppy/issues/1703#issuecomment-507202561).
+
+If you’d like to force a certain meta field data to be entered before the
+upload, you can
+[do so using `onBeforeUpload`](https://github.com/transloadit/uppy/issues/1703#issuecomment-507202561).
+
 :::
 
 :::tip
+
 If you need to restrict `allowedFileTypes` to a file extension with double dots,
-like `.nii.gz`, you can do so by [setting `allowedFileTypes` to the last part of the extension,
-`allowedFileTypes: ['.gz']`, and then using `onBeforeFileAdded` to filter for `.nii.gz`](https://github.com/transloadit/uppy/issues/1822#issuecomment-526801208).
+like `.nii.gz`, you can do so by
+[setting `allowedFileTypes` to the last part of the extension, `allowedFileTypes: ['.gz']`, and then using `onBeforeFileAdded` to filter for `.nii.gz`](https://github.com/transloadit/uppy/issues/1822#issuecomment-526801208).
+
 :::
 
 #### `meta`
@@ -255,39 +291,56 @@ like `.nii.gz`, you can do so by [setting `allowedFileTypes` to the last part of
 Key/value pairs to add to each file’s `metadata` (`Object`, default: `{}`).
 
 :::note
-Metadata from each file is then attached to uploads in the [Tus](/docs/uploaders/tus) and [XHR](/docs/uploaders/xhr) plugins.
+
+Metadata from each file is then attached to uploads in the
+[Tus](/docs/uploaders/tus) and [XHR](/docs/uploaders/xhr) plugins.
+
 :::
 
 :::info
-Two methods also exist for updating `metadata`: [`setMeta`](#setmetadata) and [`setFileMeta`](#setfilemetafileid-data).
+
+Two methods also exist for updating `metadata`: [`setMeta`](#setmetadata) and
+[`setFileMeta`](#setfilemetafileid-data).
+
 :::
 
 :::info
-Metadata can also be added from a `<form>` element on your page,
-through the [Form](#) plugin or through the UI if you are using Dashboard with the [`metaFields`](/docs/user-interfaces/dashboard#metafields) option.
+
+Metadata can also be added from a `<form>` element on your page, through the
+[Form](#) plugin or through the UI if you are using Dashboard with the
+[`metaFields`](/docs/user-interfaces/dashboard#metafields) option.
+
 :::
 
 <a id="onBeforeFileAdded" />
 
 #### `onBeforeFileAdded(file, files)`
 
-A function called before a file is added to Uppy (`Function`, default: `(file) => file`).
+A function called before a file is added to Uppy (`Function`, default:
+`(file) => file`).
 
-Use this function to run any number of custom checks on the selected file,
-or manipulate it, for instance, by optimizing a file name.
+Use this function to run any number of custom checks on the selected file, or
+manipulate it, for instance, by optimizing a file name.
 
-You can return `true` to keep the file as is, `false` to remove the file, or return a modified file.
+You can return `true` to keep the file as is, `false` to remove the file, or
+return a modified file.
 
 :::caution
-This method is intended for quick synchronous checks and modifications only.
-If you need to do an async API call, or heavy work on a file (like compression or encryption),
-you should use a [custom plugin](/docs/guides/building-plugins) instead.
+
+This method is intended for quick synchronous checks and modifications only. If
+you need to do an async API call, or heavy work on a file (like compression or
+encryption), you should use a [custom plugin](/docs/guides/building-plugins)
+instead.
+
 :::
 
 :::info
-No notification will be shown to the user about a file not passing validation by default.
-We recommend showing a message using [`uppy.info()`](#infomessage-type-duration) and logging to console
-for debugging purposes via [`uppy.log()`](#logmessage-type).
+
+No notification will be shown to the user about a file not passing validation by
+default. We recommend showing a message using
+[`uppy.info()`](#infomessage-type-duration) and logging to console for debugging
+purposes via [`uppy.log()`](#logmessage-type).
+
 :::
 
 <details>
@@ -341,23 +394,31 @@ const uppy = new Uppy({
 
 #### `onBeforeUpload(files)`
 
-A function called before when upload is initiated (`Function`, default: `(files) => files`).
+A function called before when upload is initiated (`Function`, default:
+`(files) => files`).
 
-Use this to check if all files or their total number match your requirements,
-or manipulate all the files at once before upload.
+Use this to check if all files or their total number match your requirements, or
+manipulate all the files at once before upload.
 
-You can return `true` to continue the upload, `false` to cancel it, or return modified files.
+You can return `true` to continue the upload, `false` to cancel it, or return
+modified files.
 
 :::caution
-This method is intended for quick synchronous checks and modifications only.
-If you need to do an async API call, or heavy work on a file (like compression or encryption),
-you should use a [custom plugin](/docs/guides/building-plugins) instead.
+
+This method is intended for quick synchronous checks and modifications only. If
+you need to do an async API call, or heavy work on a file (like compression or
+encryption), you should use a [custom plugin](/docs/guides/building-plugins)
+instead.
+
 :::
 
 :::info
-No notification will be shown to the user about a file not passing validation by default.
-We recommend showing a message using [`uppy.info()`](#infomessage-type-duration) and logging to console
-for debugging purposes via [`uppy.log()`](#logmessage-type).
+
+No notification will be shown to the user about a file not passing validation by
+default. We recommend showing a message using
+[`uppy.info()`](#infomessage-type-duration) and logging to console for debugging
+purposes via [`uppy.log()`](#logmessage-type).
+
 :::
 
 <details>
@@ -408,15 +469,20 @@ const uppy = new Uppy({
 
 #### `locale`
 
-You can override locale strings by passing the `strings` object
-with the keys you want to override.
+You can override locale strings by passing the `strings` object with the keys
+you want to override.
 
 :::note
+
 Array indexed objects are used for pluralisation.
+
 :::
 
 :::info
-If you want a different language it’s better to use [locales](/docs/guides/using-locales).
+
+If you want a different language it’s better to use
+[locales](/docs/guides/using-locales).
+
 :::
 
 ```js
@@ -482,15 +548,18 @@ module.exports = {
 
 #### `store`
 
-The store that is used to keep track of internal state (`Object`, default: [`DefaultStore`](/docs/custom-stores/default-store)).
+The store that is used to keep track of internal state (`Object`, default:
+[`DefaultStore`](/docs/custom-stores/default-store)).
 
-This option can be used to plug Uppy state into an external state management library, such as [Redux](/docs/custom-stores/redux-store).
+This option can be used to plug Uppy state into an external state management
+library, such as [Redux](/docs/custom-stores/redux-store).
 
 {/* TODO document store API */}
 
 #### `infoTimeout`
 
-How long an [Informer](/docs/user-interfaces/elements/informer) notification will be visible (`number`, default: `5000`).
+How long an [Informer](/docs/user-interfaces/elements/informer) notification
+will be visible (`number`, default: `5000`).
 
 ### Methods
 
@@ -520,10 +589,12 @@ Get the Uppy instance ID, see the [`id`](#id) option.
 
 #### `addFile(file)`
 
-Add a new file to Uppy’s internal state. `addFile` will return the generated id for the file that was added.
+Add a new file to Uppy’s internal state. `addFile` will return the generated id
+for the file that was added.
 
-`addFile` gives an error if the file cannot be added, either because `onBeforeFileAdded(file)` gave an error,
-or because `uppy.opts.restrictions` checks failed.
+`addFile` gives an error if the file cannot be added, either because
+`onBeforeFileAdded(file)` gave an error, or because `uppy.opts.restrictions`
+checks failed.
 
 ```js
 uppy.addFile({
@@ -541,34 +612,47 @@ uppy.addFile({
 ```
 
 :::note
+
 If you try to add a file that already exists, `addFile` will throw an error.
-Unless that duplicate file was dropped with a folder — duplicate files from different folders are allowed,
-when selected with that folder. This is because we add `file.meta.relativePath` to the `file.id`.
+Unless that duplicate file was dropped with a folder — duplicate files from
+different folders are allowed, when selected with that folder. This is because
+we add `file.meta.relativePath` to the `file.id`.
+
 :::
 
 :::info
+
 Checkout [working with Uppy files](#working-with-uppy-files).
+
 :::
 
 :::info
-If `uppy.opts.autoProceed === true`, Uppy will begin uploading automatically when files are added.
+
+If `uppy.opts.autoProceed === true`, Uppy will begin uploading automatically
+when files are added.
+
 :::
 
 :::info
-Sometimes you might need to add a remote file to Uppy.
-This can be achieved by [fetching the file, then creating a Blob object, or using the Url plugin with Companion](https://github.com/transloadit/uppy/issues/1006#issuecomment-413495493).
+
+Sometimes you might need to add a remote file to Uppy. This can be achieved by
+[fetching the file, then creating a Blob object, or using the Url plugin with Companion](https://github.com/transloadit/uppy/issues/1006#issuecomment-413495493).
+
 :::
 
 :::info
-Sometimes you might need to mark some files as “already uploaded”,
-so that the user sees them, but they won’t actually be uploaded by Uppy.
-This can be achieved by [looping through files and setting `uploadComplete: true, uploadStarted: true` on them](https://github.com/transloadit/uppy/issues/1112#issuecomment-432339569)
+
+Sometimes you might need to mark some files as “already uploaded”, so that the
+user sees them, but they won’t actually be uploaded by Uppy. This can be
+achieved by
+[looping through files and setting `uploadComplete: true, uploadStarted: true` on them](https://github.com/transloadit/uppy/issues/1112#issuecomment-432339569)
+
 :::
 
 #### `removeFile(fileID)`
 
-Remove a file from Uppy.
-Removing a file that is already being uploaded cancels that upload.
+Remove a file from Uppy. Removing a file that is already being uploaded cancels
+that upload.
 
 ```js
 uppy.removeFile('uppyteamkongjpg1501851828779');
@@ -594,10 +678,12 @@ const files = uppy.getFiles();
 
 Start uploading added files.
 
-Returns a Promise `result` that resolves with an object containing two arrays of uploaded files:
+Returns a Promise `result` that resolves with an object containing two arrays of
+uploaded files:
 
 - `result.successful` - Files that were uploaded successfully.
-- `result.failed` - Files that did not upload successfully. These files will have a `.error` property describing what went wrong.
+- `result.failed` - Files that did not upload successfully. These files will
+  have a `.error` property describing what went wrong.
 
 ```js
 uppy.upload().then((result) => {
@@ -614,15 +700,18 @@ uppy.upload().then((result) => {
 
 #### `pauseResume(fileID)`
 
-Toggle pause/resume on an upload. Will only work if resumable upload plugin, such as [Tus](/docs/uploaders/tus/), is used.
+Toggle pause/resume on an upload. Will only work if resumable upload plugin,
+such as [Tus](/docs/uploaders/tus/), is used.
 
 #### `pauseAll()`
 
-Pause all uploads. Will only work if a resumable upload plugin, such as [Tus](/docs/uploaders/tus/), is used.
+Pause all uploads. Will only work if a resumable upload plugin, such as
+[Tus](/docs/uploaders/tus/), is used.
 
 #### `resumeAll()`
 
-Resume all uploads. Will only work if resumable upload plugin, such as [Tus](/docs/uploaders/tus/), is used.
+Resume all uploads. Will only work if resumable upload plugin, such as
+[Tus](/docs/uploaders/tus/), is used.
 
 #### `retryUpload(fileID)`
 
@@ -638,8 +727,9 @@ Cancel all uploads, reset progress and remove all files.
 
 #### `setState(patch)`
 
-Update Uppy’s internal state. Usually, this method is called internally,
-but in some cases it might be useful to alter something directly, especially when implementing your own plugins.
+Update Uppy’s internal state. Usually, this method is called internally, but in
+some cases it might be useful to alter something directly, especially when
+implementing your own plugins.
 
 Uppy’s default state on initialization:
 
@@ -668,9 +758,12 @@ uppy.setState({ smth: true });
 ```
 
 :::note
-State in Uppy is considered to be immutable.
-When updating values, make sure not mutate them, but instead create copies.
-See [Redux docs](http://redux.js.org/docs/recipes/UsingObjectSpreadOperator.html) for more info on this.
+
+State in Uppy is considered to be immutable. When updating values, make sure not
+mutate them, but instead create copies. See
+[Redux docs](http://redux.js.org/docs/recipes/UsingObjectSpreadOperator.html)
+for more info on this.
+
 :::
 
 #### `getState()`
@@ -679,15 +772,18 @@ Returns the current state from the [Store](#store).
 
 #### `setFileState(fileID, state)`
 
-Update the state for a single file. This is mostly useful for plugins that may want to store data on [Uppy files](#working-with-uppy-files),
-or need to pass file-specific configurations to other plugins that support it.
+Update the state for a single file. This is mostly useful for plugins that may
+want to store data on [Uppy files](#working-with-uppy-files), or need to pass
+file-specific configurations to other plugins that support it.
 
-`fileID` is the string file ID. `state` is an object that will be merged into the file’s state object.
+`fileID` is the string file ID. `state` is an object that will be merged into
+the file’s state object.
 
 #### `setMeta(data)`
 
-Alters global `meta` object in state, the one that can be set in Uppy options and gets merged with all newly added files.
-Calling `setMeta` will also merge newly added meta data with files that had been selected before.
+Alters global `meta` object in state, the one that can be set in Uppy options
+and gets merged with all newly added files. Calling `setMeta` will also merge
+newly added meta data with files that had been selected before.
 
 ```js
 uppy.setMeta({ resize: 1500, token: 'ab5kjfg' });
@@ -733,18 +829,20 @@ uppy.getPlugin('Dashboard').setOptions({
 
 #### `reset()`
 
-Stop all uploads in progress and clear file selection, set progress to 0.
-More or less, it returns things to the way they were before any user input.
+Stop all uploads in progress and clear file selection, set progress to 0. More
+or less, it returns things to the way they were before any user input.
 
 #### `close()`
 
-Uninstall all plugins and close down this Uppy instance. Also runs `uppy.reset()` before uninstalling.
+Uninstall all plugins and close down this Uppy instance. Also runs
+`uppy.reset()` before uninstalling.
 
 #### `logout()`
 
-Calls `provider.logout()` on each remote provider plugin (Google Drive, Instagram, etc).
-Useful, for example, after your users log out of their account in your app
-— this will clean things up with Uppy cloud providers as well, for extra security.
+Calls `provider.logout()` on each remote provider plugin (Google Drive,
+Instagram, etc). Useful, for example, after your users log out of their account
+in your app — this will clean things up with Uppy cloud providers as well, for
+extra security.
 
 #### `log(message, type)`
 
@@ -761,8 +859,10 @@ uppy.log('[Dashboard] adding files...');
 
 #### `info(message, type, duration)`
 
-Sets a message in state, with optional details, that can be shown by notification UI plugins.
-It’s using the [Informer](/docs/interfaces/elements/informer/) plugin, included by default in Dashboard.
+Sets a message in state, with optional details, that can be shown by
+notification UI plugins. It’s using the
+[Informer](/docs/interfaces/elements/informer/) plugin, included by default in
+Dashboard.
 
 | Argument   | Type               | Description                                                                       |
 | ---------- | ------------------ | --------------------------------------------------------------------------------- |
@@ -770,7 +870,8 @@ It’s using the [Informer](/docs/interfaces/elements/informer/) plugin, include
 | `type`     | `string?`          | `'info'`, `'warning'`, `'success'` or `'error'`                                   |
 | `duration` | `number?`          | in milliseconds                                                                   |
 
-`info-visible` and `info-hidden` events are emitted when this info message should be visible or hidden.
+`info-visible` and `info-hidden` events are emitted when this info message
+should be visible or hidden.
 
 ```js
 this.info('Oh my, something good happened!', 'success', 3000);
@@ -790,42 +891,47 @@ this.info(
 
 #### `addPreProcessor(fn)`
 
-Add a preprocessing function.
-`fn` gets called with a list of file IDs before an upload starts.
-`fn` should return a Promise. Its resolution value is ignored.
+Add a preprocessing function. `fn` gets called with a list of file IDs before an
+upload starts. `fn` should return a Promise. Its resolution value is ignored.
 
 :::info
-To change file data and such, use Uppy state updates, for example using [`setFileState`](#setfilestatefileid-state).
+
+To change file data and such, use Uppy state updates, for example using
+[`setFileState`](#setfilestatefileid-state).
+
 :::
 
 #### `addUploader(fn)`
 
-Add an uploader function.
-`fn` gets called with a list of file IDs when an upload should start.
-Uploader functions should do the actual uploading work,
-such as creating and sending an XMLHttpRequest or calling into some upload service SDK.
-`fn` should return a Promise that resolves once all files have been uploaded.
+Add an uploader function. `fn` gets called with a list of file IDs when an
+upload should start. Uploader functions should do the actual uploading work,
+such as creating and sending an XMLHttpRequest or calling into some upload
+service SDK. `fn` should return a Promise that resolves once all files have been
+uploaded.
 
 :::tip
-You may choose to still resolve the Promise if some file uploads fail.
-This way, any postprocessing will still run on the files that were uploaded successfully,
-while uploads that failed will be retried when [`retryAll`](#retryall) is called.
+
+You may choose to still resolve the Promise if some file uploads fail. This way,
+any postprocessing will still run on the files that were uploaded successfully,
+while uploads that failed will be retried when [`retryAll`](#retryall) is
+called.
+
 :::
 
 #### `addPostProcessor(fn)`
 
-Add a postprocessing function.
-`fn` is called with a list of file IDs when an upload has finished.
-`fn` should return a Promise that resolves when the processing work is complete.
-The value of the Promise is ignored.
+Add a postprocessing function. `fn` is called with a list of file IDs when an
+upload has finished. `fn` should return a Promise that resolves when the
+processing work is complete. The value of the Promise is ignored.
 
-For example, you could wait for file encoding or CDN propagation to complete,
-or you could do an HTTP API call to create an album containing all images that were uploaded.
+For example, you could wait for file encoding or CDN propagation to complete, or
+you could do an HTTP API call to create an album containing all images that were
+uploaded.
 
 #### `removePreProcessor/removeUploader/removePostProcessor(fn)`
 
-Remove a processor or uploader function that was added before.
-Normally, this should be done in the [`uninstall()`](#uninstall) method.
+Remove a processor or uploader function that was added before. Normally, this
+should be done in the [`uninstall()`](#uninstall) method.
 
 #### `on('event', action)`
 
@@ -861,7 +967,8 @@ uppy.on('file-added', (file) => {
 
 **Parameters**
 
-- `files` - Array of [Uppy files](#working-with-uppy-files) which were added at once, in a batch.
+- `files` - Array of [Uppy files](#working-with-uppy-files) which were added at
+  once, in a batch.
 
 Fired each time when one or more files are added — one event, for all files
 
@@ -872,9 +979,9 @@ Fired each time a file is removed.
 **Parameters**
 
 - `file` - The [Uppy file](#working-with-uppy-files) that was removed.
-- `reason` - A string explaining why the file was removed.
-  See [#2301](https://github.com/transloadit/uppy/issues/2301#issue-628931176) for details.
-  Current reasons are: `removed-by-user` and `cancel-all`.
+- `reason` - A string explaining why the file was removed. See
+  [#2301](https://github.com/transloadit/uppy/issues/2301#issue-628931176) for
+  details. Current reasons are: `removed-by-user` and `cancel-all`.
 
 **Example**
 
@@ -916,7 +1023,8 @@ Progress of the pre-processors.
 `progress` is an object with properties:
 
 - `mode` - Either `'determinate'` or `'indeterminate'`.
-- `message` - A message to show to the user. Something like `'Preparing upload...'`, but be more specific if possible.
+- `message` - A message to show to the user. Something like
+  `'Preparing upload...'`, but be more specific if possible.
 
 When `mode` is `'determinate'`, also add the `value` property:
 
@@ -967,7 +1075,8 @@ Progress of the post-processors.
 `progress` is an object with properties:
 
 - `mode` - Either `'determinate'` or `'indeterminate'`.
-- `message` - A message to show to the user. Something like `'Preparing upload...'`, but be more specific if possible.
+- `message` - A message to show to the user. Something like
+  `'Preparing upload...'`, but be more specific if possible.
 
 When `mode` is `'determinate'`, also add the `value` property:
 
@@ -980,8 +1089,8 @@ Fired each time a single upload is completed.
 **Parameters**
 
 - `file` - The [Uppy file](#working-with-uppy-files) that was uploaded.
-- `response` - An object with response data from the remote endpoint.
-  The actual contents depend on the upload plugin that is used.
+- `response` - An object with response data from the remote endpoint. The actual
+  contents depend on the upload plugin that is used.
 
 For `@uppy/xhr-upload`, the shape is:
 
@@ -1010,8 +1119,8 @@ uppy.on('upload-success', (file, response) => {
 
 Fired when all uploads are complete.
 
-The `result` parameter is an object with arrays of `successful` and `failed` files,
-as in [`uppy.upload()`](#upload)’s return value.
+The `result` parameter is an object with arrays of `successful` and `failed`
+files, as in [`uppy.upload()`](#upload)’s return value.
 
 ```js
 uppy.on('complete', (result) => {
@@ -1044,9 +1153,11 @@ Fired each time a single upload failed.
 
 - `file` - The [Uppy file](#working-with-uppy-files) which didn’t upload.
 - `error` - The error object.
-- `response` - an optional parameter with response data from the upload endpoint.
+- `response` - an optional parameter with response data from the upload
+  endpoint.
 
-It may be undefined or contain different data depending on the upload plugin in use.
+It may be undefined or contain different data depending on the upload plugin in
+use.
 
 For `@uppy/xhr-upload`, the shape is:
 
@@ -1066,9 +1177,10 @@ uppy.on('upload-error', (file, error, response) => {
 });
 ```
 
-If the error is related to network conditions — endpoint unreachable due to firewall or ISP blockage,
-for instance — the error will have `error.isNetworkError` property set to `true`.
-Here’s how you can check for network errors:
+If the error is related to network conditions — endpoint unreachable due to
+firewall or ISP blockage, for instance — the error will have
+`error.isNetworkError` property set to `true`. Here’s how you can check for
+network errors:
 
 ```js
 uppy.on('upload-error', (file, error, response) => {
@@ -1085,7 +1197,10 @@ uppy.on('upload-error', (file, error, response) => {
 Fired when an upload has been retried (after an error, for example).
 
 :::note
-This event is not triggered when the user retries all uploads, it will trigger the `retry-all` event instead.
+
+This event is not triggered when the user retries all uploads, it will trigger
+the `retry-all` event instead.
+
 :::
 
 **Parameters**
@@ -1102,7 +1217,10 @@ uppy.on('upload-retry', (fileID) => {
 
 #### `upload-stalled`
 
-Fired when an upload has not received any progress in some time (in `@uppy/xhr-upload`, the delay is defined by the `timeout` option). Use this event to display a message on the UI to tell the user they might want to retry the upload.
+Fired when an upload has not received any progress in some time (in
+`@uppy/xhr-upload`, the delay is defined by the `timeout` option). Use this
+event to display a message on the UI to tell the user they might want to retry
+the upload.
 
 ```js
 uppy.on('upload-stalled', (error, files) => {
@@ -1135,7 +1253,9 @@ uppy.on('upload-retry', (fileIDs) => {
 
 #### `info-visible`
 
-Fired when “info” message should be visible in the UI. By default, `Informer` plugin is displaying these messages (enabled by default in `Dashboard` plugin). You can use this event to show messages in your custom UI:
+Fired when “info” message should be visible in the UI. By default, `Informer`
+plugin is displaying these messages (enabled by default in `Dashboard` plugin).
+You can use this event to show messages in your custom UI:
 
 ```js
 uppy.on('info-visible', () => {
@@ -1152,16 +1272,19 @@ uppy.on('info-visible', () => {
 
 #### `info-hidden`
 
-Fired when “info” message should be hidden in the UI. See [`info-visible`](#info-visible).
+Fired when “info” message should be hidden in the UI. See
+[`info-visible`](#info-visible).
 
 #### `cancel-all`
 
-Fired when `cancelAll()` is called, all uploads are canceled, files removed and progress is reset.
+Fired when `cancelAll()` is called, all uploads are canceled, files removed and
+progress is reset.
 
 #### `restriction-failed`
 
-Fired when a file violates certain restrictions when added.
-This event is providing another choice for those who want to customize the behavior of file upload restrictions.
+Fired when a file violates certain restrictions when added. This event is
+providing another choice for those who want to customize the behavior of file
+upload restrictions.
 
 ```js
 uppy.on('restriction-failed', (file, error) => {
@@ -1171,7 +1294,8 @@ uppy.on('restriction-failed', (file, error) => {
 
 #### `reset-progress`
 
-Fired when `resetProgress()` is called, each file has its upload progress reset to zero.
+Fired when `resetProgress()` is called, each file has its upload progress reset
+to zero.
 
 ```js
 uppy.on('reset-progress', () => {
@@ -1187,21 +1311,30 @@ The initial building block for a plugin.
 without an user interface.
 
 :::info
-See [`UIPlugin`][] for the extended version with Preact rendering for interfaces.
+
+See [`UIPlugin`][] for the extended version with Preact rendering for
+interfaces.
+
 :::
 
 :::info
+
 Checkout the [building plugins](/docs/guides/building-plugins) guide.
+
 :::
 
 :::note
-If you don’t use any UI plugins and want to make sure Preact isn’t bundled into your app,
-import `BasePlugin` like this: `import BasePlugin from '@uppy/core/lib/BasePlugin`.
+
+If you don’t use any UI plugins and want to make sure Preact isn’t bundled into
+your app, import `BasePlugin` like this:
+`import BasePlugin from '@uppy/core/lib/BasePlugin`.
+
 :::
 
 ### Options
 
-The options passed to `BasePlugin` are all you options you wish to support in your plugin.
+The options passed to `BasePlugin` are all you options you wish to support in
+your plugin.
 
 You should pass the options to `super` in your plugin class:
 
@@ -1217,27 +1350,26 @@ class MyPlugin extends BasePlugin {
 
 #### `setOptions(options)`
 
-Options passed during initialization can also be altered dynamically with `setOptions`.
+Options passed during initialization can also be altered dynamically with
+`setOptions`.
 
 #### `getPluginState()`
 
-Retrieves the plugin state from the `Uppy` class.
-Uppy keeps a `plugins` object in state in which each key is the plugin’s `id`,
-and the value its state.
+Retrieves the plugin state from the `Uppy` class. Uppy keeps a `plugins` object
+in state in which each key is the plugin’s `id`, and the value its state.
 
 #### `setPluginState()`
 
-Set the plugin state in the `Uppy` class.
-Uppy keeps a `plugins` object in state in which each key is the plugin’s `id`,
-and the value its state.
+Set the plugin state in the `Uppy` class. Uppy keeps a `plugins` object in state
+in which each key is the plugin’s `id`, and the value its state.
 
 #### `install()`
 
-The `install` method is ran once, when the plugin is added to Uppy with `.use()`.
-Use this to initialize the plugin.
+The `install` method is ran once, when the plugin is added to Uppy with
+`.use()`. Use this to initialize the plugin.
 
-For example, if you are creating a pre-processor (such as [@uppy/compressor](/docs/compressor))
-you must add it:
+For example, if you are creating a pre-processor (such as
+[@uppy/compressor](/docs/compressor)) you must add it:
 
 ```js
 install () {
@@ -1245,8 +1377,9 @@ install () {
 }
 ```
 
-Another common thing to do when creating a [UI plugin](#new-uipluginuppy-options)
-is to [`mount`](#mounttarget) it to the DOM:
+Another common thing to do when creating a
+[UI plugin](#new-uipluginuppy-options) is to [`mount`](#mounttarget) it to the
+DOM:
 
 ```js
 install () {
@@ -1259,13 +1392,14 @@ install () {
 
 #### `uninstall()`
 
-The `uninstall` method is ran once, when the plugin is removed from Uppy.
-This happens when `.close()` is called or when the plugin is destroyed in
-a framework integration.
+The `uninstall` method is ran once, when the plugin is removed from Uppy. This
+happens when `.close()` is called or when the plugin is destroyed in a framework
+integration.
 
 Use this to clean things up.
 
-For instance when creating a pre-processor, uploader, or post-processor to remove it:
+For instance when creating a pre-processor, uploader, or post-processor to
+remove it:
 
 ```js
 uninstall () {
@@ -1273,7 +1407,8 @@ uninstall () {
 }
 ```
 
-When creating a [UI plugin](#new-uipluginuppy-options) you should [`unmount`](#unmount) it from the DOM:
+When creating a [UI plugin](#new-uipluginuppy-options) you should
+[`unmount`](#unmount) it from the DOM:
 
 ```js
 uninstall () {
@@ -1288,13 +1423,13 @@ initialize [internationalisation](/docs/guides/using-locales).
 
 #### `addTarget`
 
-You can use this method to make your plugin a `target` for other plugins.
-This is what `@uppy/dashboard` uses to add other plugins to its UI.
+You can use this method to make your plugin a `target` for other plugins. This
+is what `@uppy/dashboard` uses to add other plugins to its UI.
 
 #### `update`
 
-Called on each state update. You will rarely need to use this,
-unless if you want to build a UI plugin using something other than Preact.
+Called on each state update. You will rarely need to use this, unless if you
+want to build a UI plugin using something other than Preact.
 
 #### `afterUpdate`
 
@@ -1302,20 +1437,26 @@ Called after every state update with a debounce, after everything has mounted.
 
 ## `new UIPlugin(uppy, options?)`
 
-`UIPlugin` extends [`BasePlugin`][] to add rendering with [Preact](https://preactjs.com/).
-Use this when you want to create an user interface or an addition to one, such as [Dashboard][].
+`UIPlugin` extends [`BasePlugin`][] to add rendering with
+[Preact](https://preactjs.com/). Use this when you want to create an user
+interface or an addition to one, such as [Dashboard][].
 
 :::info
+
 See [`BasePlugin`][] for the initial building block for all plugins.
+
 :::
 
 :::info
+
 Checkout the [building plugins](/docs/guides/building-plugins) guide.
+
 :::
 
 ### Options
 
-The options passed to `UIPlugin` are all you options you wish to support in your plugin.
+The options passed to `UIPlugin` are all you options you wish to support in your
+plugin.
 
 You should pass the options to `super` in your plugin class:
 
@@ -1336,8 +1477,9 @@ All the methods from [`BasePlugin`][] are also inherited into `UIPlugin`.
 #### `mount(target)`
 
 Mount this plugin to the `target` element. `target` can be a CSS query selector,
-a DOM element, or another Plugin. If `target` is a Plugin, the source (current) plugin
-will register with the target plugin, and the latter can decide how and where to render the source plugin.
+a DOM element, or another Plugin. If `target` is a Plugin, the source (current)
+plugin will register with the target plugin, and the latter can decide how and
+where to render the source plugin.
 
 #### `onMount()`
 
@@ -1345,8 +1487,8 @@ Called after Preact has rendered the components of the plugin.
 
 #### `unmount`
 
-Removing the plugin from the DOM.
-You generally don’t need to override it but you should call it from [`uninstall`](#uninstall).
+Removing the plugin from the DOM. You generally don’t need to override it but
+you should call it from [`uninstall`](#uninstall).
 
 The default is:
 
@@ -1361,17 +1503,19 @@ unmount () {
 
 #### `onUnmount()`
 
-Called after the elements have been removed from the DOM. Can be used to do some clean up or other side-effects.
+Called after the elements have been removed from the DOM. Can be used to do some
+clean up or other side-effects.
 
 #### `render()`
 
-Render the UI of the plugin. Uppy uses [Preact](https://preactjs.com) as its view engine,
-so `render()` should return a Preact element. `render` is automatically called by Uppy on each state change.
+Render the UI of the plugin. Uppy uses [Preact](https://preactjs.com) as its
+view engine, so `render()` should return a Preact element. `render` is
+automatically called by Uppy on each state change.
 
 #### `update(state)`
 
-Called on each state update. You will rarely need to use this,
-unless if you want to build a UI plugin using something other than Preact.
+Called on each state update. You will rarely need to use this, unless if you
+want to build a UI plugin using something other than Preact.
 
 ## `debugLogger()`
 
@@ -1384,10 +1528,13 @@ new Uppy({ logger: debugLogger });
 ```
 
 :::info
+
 You can also enable this logger by setting [`debug`](#debug) to `true`.
+
 :::
 
-The default value of [`logger`](#logger) is `justErrorsLogger`, which looks like this:
+The default value of [`logger`](#logger) is `justErrorsLogger`, which looks like
+this:
 
 ```js
 // Swallow all logs, except errors.

--- a/docs/user-interfaces/dashboard.mdx
+++ b/docs/user-interfaces/dashboard.mdx
@@ -9,24 +9,36 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # Dashboard
 
-The all you need Dashboard — powerful, responsive, and pluggable.
-Kickstart your uploading experience and gradually add more functionality.
-Add files from [remote sources](/docs/companion), [edit images](/docs/user-interface/elements/image-editor), [generate thumbnails](/docs/user-interface/elements/thumbnail-generator), and more.
+The all you need Dashboard — powerful, responsive, and pluggable. Kickstart your
+uploading experience and gradually add more functionality. Add files from
+[remote sources](/docs/companion),
+[edit images](/docs/user-interface/elements/image-editor),
+[generate thumbnails](/docs/user-interface/elements/thumbnail-generator), and
+more.
 
-Checkout [integrations](#integrations) for the full list of plugins you can integrate.
+Checkout [integrations](#integrations) for the full list of plugins you can
+integrate.
 
 :::tip
-[Try out the live example with all plugins](/examples) or take it for a spin in [CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
+[Try out the live example with all plugins](/examples) or take it for a spin in
+[CodeSandbox](https://codesandbox.io/s/uppy-dashboard-xpxuhd).
+
 :::
 
 ## When should I use this?
 
-There could be many reasons why you may want to use the Dashboard, but some could be:
+There could be many reasons why you may want to use the Dashboard, but some
+could be:
 
 - when you need a battle tested plug-and-play uploading UI to save time.
-- when your users need to add files from [remote sources](/docs/companion), such [Google Drive](/docs/sources/companion-plugins/google-drive), [Dropbox](/docs/sources/companion-plugins/dropbox), and others.
+- when your users need to add files from [remote sources](/docs/companion), such
+  [Google Drive](/docs/sources/companion-plugins/google-drive),
+  [Dropbox](/docs/sources/companion-plugins/dropbox), and others.
 - when you need to collect [meta data](#metafields) from your users per file.
-- when your users want to take a picture with their [webcam](/docs/sources/webcam) or [capture their screen](/docs/sources/screen-capture).
+- when your users want to take a picture with their
+  [webcam](/docs/sources/webcam) or
+  [capture their screen](/docs/sources/screen-capture).
 
 ## Install
 
@@ -71,16 +83,24 @@ new Uppy().use(Dashboard, { inline: true, target: '#uppy-dashboard' });
 ```
 
 :::note
-The `@uppy/dashboard` plugin includes CSS for the Dashboard itself, and the various plugins used by the Dashboard,
-such as ([`@uppy/status-bar`](/docs/user-interfaces/elements/status-bar) and [`@uppy/informer`](/docs/user-interfaces/elements/informer)).
-If you also use the `@uppy/status-bar` or `@uppy/informer` plugin directly,
-you should not include their CSS files, but instead only use the one from the `@uppy/dashboard` plugin.
+
+The `@uppy/dashboard` plugin includes CSS for the Dashboard itself, and the
+various plugins used by the Dashboard, such as
+([`@uppy/status-bar`](/docs/user-interfaces/elements/status-bar) and
+[`@uppy/informer`](/docs/user-interfaces/elements/informer)). If you also use
+the `@uppy/status-bar` or `@uppy/informer` plugin directly, you should not
+include their CSS files, but instead only use the one from the `@uppy/dashboard`
+plugin.
+
 :::
 
 :::note
-Styles for Provider plugins, like Google Drive and Instagram, are also bundled with Dashboard styles.
-Styles for other plugins, such as `@uppy/url` and `@uppy/webcam`, are not included.
-If you are using those, please see their docs and make sure to include styles for them as well.
+
+Styles for Provider plugins, like Google Drive and Instagram, are also bundled
+with Dashboard styles. Styles for other plugins, such as `@uppy/url` and
+`@uppy/webcam`, are not included. If you are using those, please see their docs
+and make sure to include styles for them as well.
+
 :::
 
 ## API
@@ -91,55 +111,70 @@ If you are using those, please see their docs and make sure to include styles fo
 
 A unique identifier for this plugin (`string`, default: `'Dashboard'`).
 
-Plugins that are added by the Dashboard get unique IDs based on this ID, like `'Dashboard:StatusBar'` and `'Dashboard:Informer'`.
+Plugins that are added by the Dashboard get unique IDs based on this ID, like
+`'Dashboard:StatusBar'` and `'Dashboard:Informer'`.
 
 #### `target`
 
 Where to render the Dashboard (`string` or `Element`, default: `'body'`).
 
-You can pass an element, class, or id as a string.
-Dashboard is rendered into `body`, because it’s hidden by default and only opened as a modal when `trigger` is clicked.
+You can pass an element, class, or id as a string. Dashboard is rendered into
+`body`, because it’s hidden by default and only opened as a modal when `trigger`
+is clicked.
 
 #### `inline`
 
 Render the Dashboard as a modal or inline (`boolean`, default: `false`).
 
-When `false`, Dashboard is opened by clicking on [`trigger`](#trigger).
-If `inline: true`, Dashboard will be rendered into [`target`](#target) and fit right in.
+When `false`, Dashboard is opened by clicking on [`trigger`](#trigger). If
+`inline: true`, Dashboard will be rendered into [`target`](#target) and fit
+right in.
 
 #### `trigger`
 
-A CSS selector for a button that will trigger opening the Dashboard modal (`string`, default: `null`).
+A CSS selector for a button that will trigger opening the Dashboard modal
+(`string`, default: `null`).
 
-Several buttons or links can be used, as long as they are selected using the same selector (`.select-file-button`, for example).
+Several buttons or links can be used, as long as they are selected using the
+same selector (`.select-file-button`, for example).
 
 #### `width`
 
-Width of the Dashboard in pixels (`number`, default: `750`). Used when `inline: true`.
+Width of the Dashboard in pixels (`number`, default: `750`). Used when
+`inline: true`.
 
 #### `height`
 
-Height of the Dashboard in pixels (`number`, default: `550`). Used when `inline: true`.
+Height of the Dashboard in pixels (`number`, default: `550`). Used when
+`inline: true`.
 
 #### `waitForThumbnailsBeforeUpload`
 
-Whether to wait for all thumbnails from `@uppy/thumbnail-generator` to be ready before starting the upload (`boolean`, default `false`).
+Whether to wait for all thumbnails from `@uppy/thumbnail-generator` to be ready
+before starting the upload (`boolean`, default `false`).
 
-If set to `true`, Thumbnail Generator will envoke Uppy’s internal processing stage, displaying “Generating thumbnails...” message, and wait for `thumbnail:all-generated` event, before proceeding to the uploading stage.
+If set to `true`, Thumbnail Generator will envoke Uppy’s internal processing
+stage, displaying “Generating thumbnails...” message, and wait for
+`thumbnail:all-generated` event, before proceeding to the uploading stage.
 
-This is useful because Thumbnail Generator also adds EXIF data to images, and if we wait until it’s done processing, this data will be avilable on the server after the upload.
+This is useful because Thumbnail Generator also adds EXIF data to images, and if
+we wait until it’s done processing, this data will be avilable on the server
+after the upload.
 
 #### `showLinkToFileUploadResult`
 
-Turn the file icon and thumbnail in the Dashboard into a link to the uploaded file (`boolean`, default: `false`).
+Turn the file icon and thumbnail in the Dashboard into a link to the uploaded
+file (`boolean`, default: `false`).
 
-Please make sure to return the `url` key (or the one set via `responseUrlFieldName`) from your server.
+Please make sure to return the `url` key (or the one set via
+`responseUrlFieldName`) from your server.
 
 #### `showProgressDetails`
 
 Show or hise progress details in the status bar (`boolean`, default: `false`).
 
-By default, progress in Status Bar is shown as a percentage. If you would like to also display remaining upload size and time, set this to `true`.
+By default, progress in Status Bar is shown as a percentage. If you would like
+to also display remaining upload size and time, set this to `true`.
 
 `showProgressDetails: false`: Uploading: 45%
 
@@ -149,26 +184,33 @@ By default, progress in Status Bar is shown as a percentage. If you would like t
 
 Show or hide the upload button (`boolean`, default: `false`).
 
-Use this if you are providing a custom upload button somewhere, and are using the `uppy.upload()` API.
+Use this if you are providing a custom upload button somewhere, and are using
+the `uppy.upload()` API.
 
 #### `hideRetryButton`
 
-Hide the retry button in the status bar and on each individual file (`boolean`, default: `false`).
+Hide the retry button in the status bar and on each individual file (`boolean`,
+default: `false`).
 
-Use this if you are providing a custom retry button somewhere and if you are using the `uppy.retryAll()` or `uppy.retryUpload(fileID)` API.
+Use this if you are providing a custom retry button somewhere and if you are
+using the `uppy.retryAll()` or `uppy.retryUpload(fileID)` API.
 
 #### `hidePauseResumeButton`
 
-Hide the pause/resume button (for resumable uploads, via [tus](http://tus.io), for example) in the status bar and on each individual file
-(`boolean`, default: `false`).
+Hide the pause/resume button (for resumable uploads, via [tus](http://tus.io),
+for example) in the status bar and on each individual file (`boolean`, default:
+`false`).
 
-Use this if you are providing custom cancel or pause/resume buttons somewhere, and using the `uppy.pauseResume(fileID)` or `uppy.removeFile(fileID)` API.
+Use this if you are providing custom cancel or pause/resume buttons somewhere,
+and using the `uppy.pauseResume(fileID)` or `uppy.removeFile(fileID)` API.
 
 #### `hideCancelButton`
 
-Hide the cancel button in status bar and on each individual file (`boolean`, default: `false`).
+Hide the cancel button in status bar and on each individual file (`boolean`,
+default: `false`).
 
-Use this if you are providing a custom retry button somewhere, and using the `uppy.cancelAll()` API.
+Use this if you are providing a custom retry button somewhere, and using the
+`uppy.cancelAll()` API.
 
 #### `hideProgressAfterFinish`
 
@@ -176,8 +218,10 @@ Hide the status bar after the upload has finished (`boolean`, default: `false`).
 
 #### `doneButtonHandler()`
 
-This option is passed to the status bar and will render a “Done” button in place of pause/resume/cancel buttons, once the upload/encoding is done.
-The behaviour of this “Done” button is defined by this handler function, for instance to close the file picker modals or clear the upload state.
+This option is passed to the status bar and will render a “Done” button in place
+of pause/resume/cancel buttons, once the upload/encoding is done. The behaviour
+of this “Done” button is defined by this handler function, for instance to close
+the file picker modals or clear the upload state.
 
 This is what the Dashboard sets by default:
 
@@ -192,18 +236,24 @@ Set to `null` to disable the “Done” button.
 
 #### `showSelectedFiles`
 
-Show the list of added files with a preview and file information (`boolean`, default: `true`).
+Show the list of added files with a preview and file information (`boolean`,
+default: `true`).
 
-In case you are showing selected files in your own app’s UI and want the Uppy Dashboard to only be a picker, the list can be hidden with this option.
+In case you are showing selected files in your own app’s UI and want the Uppy
+Dashboard to only be a picker, the list can be hidden with this option.
 
-See also [`disableStatusBar`](#disablestatusbar) option, which can hide the progress and upload button.
+See also [`disableStatusBar`](#disablestatusbar) option, which can hide the
+progress and upload button.
 
 #### `showRemoveButtonAfterComplete`
 
-Show the remove button on every file after a successful upload (`boolean`, default: `false`).
+Show the remove button on every file after a successful upload (`boolean`,
+default: `false`).
 
-Enabling this option only shows the remove `X` button in the Dashboard UI,
-but to actually send a request you should listen to [`file-removed`](https://uppy.io/docs/uppy/#file-removed) event and add your logic there.
+Enabling this option only shows the remove `X` button in the Dashboard UI, but
+to actually send a request you should listen to
+[`file-removed`](https://uppy.io/docs/uppy/#file-removed) event and add your
+logic there.
 
 Example:
 
@@ -215,38 +265,53 @@ uppy.on('file-removed', (file, reason) => {
 });
 ```
 
-For an implementation example, please see [#2301](https://github.com/transloadit/uppy/issues/2301#issue-628931176).
+For an implementation example, please see
+[#2301](https://github.com/transloadit/uppy/issues/2301#issue-628931176).
 
 #### `note`
 
 A string of text to be placed in the Dashboard UI (`string`, default: `null`).
 
-This could for instance be used to explain any [`restrictions`](#restrictions) that are put in place.
-For example: `'Images and video only, 2–3 files, up to 1 MB'`.
+This could for instance be used to explain any [`restrictions`](#restrictions)
+that are put in place. For example:
+`'Images and video only, 2–3 files, up to 1 MB'`.
 
 #### `metaFields`
 
-Create text or custom input fields for the user to fill in (`Array<Object>` or `Function`, default: `null`).
+Create text or custom input fields for the user to fill in (`Array<Object>` or
+`Function`, default: `null`).
 
 This will be shown when a user clicks the “edit” button on that file.
 
 :::note
-The meta data will only be set on a file object if it’s entered by the user.
-If the user doesn’t edit a file’s metadata, it will not have default values; instead everything will be `undefined`.
-If you want to set a certain meta field to each file regardless of user actions, set [`meta` in the Uppy constructor options](/docs/uppy-core/#meta).
+
+The meta data will only be set on a file object if it’s entered by the user. If
+the user doesn’t edit a file’s metadata, it will not have default values;
+instead everything will be `undefined`. If you want to set a certain meta field
+to each file regardless of user actions, set
+[`meta` in the Uppy constructor options](/docs/uppy-core/#meta).
+
 :::
 
 Each object can contain:
 
-- `id`. The name of the meta field. This will also be used in CSS/HTML as part of the `id` attribute, so it’s better to [avoid using characters like periods, semicolons, etc](https://stackoverflow.com/a/79022).
+- `id`. The name of the meta field. This will also be used in CSS/HTML as part
+  of the `id` attribute, so it’s better to
+  [avoid using characters like periods, semicolons, etc](https://stackoverflow.com/a/79022).
 - `name`. The label shown in the interface.
-- `placeholder`. The text shown when no value is set in the field. (Not needed when a custom render function is provided)
-- `render: ({value, onChange, required, form}, h) => void` (optional). A function for rendering a custom form element.
+- `placeholder`. The text shown when no value is set in the field. (Not needed
+  when a custom render function is provided)
+- `render: ({value, onChange, required, form}, h) => void` (optional). A
+  function for rendering a custom form element.
   - `value` is the current value of the meta field
-  - `onChange: (newVal) => void` is a function saving the new value and `h` is the `createElement` function from [Preact](https://preactjs.com/guide/v10/api-reference#h--createelement).
-  - `required` is a boolean that’s true if the field `id` is in the `restrictedMetaFields` restriction
+  - `onChange: (newVal) => void` is a function saving the new value and `h` is
+    the `createElement` function from
+    [Preact](https://preactjs.com/guide/v10/api-reference#h--createelement).
+  - `required` is a boolean that’s true if the field `id` is in the
+    `restrictedMetaFields` restriction
   - `form` is the `id` of the associated `<form>` element.
-  - `h` can be useful when using Uppy from plain JavaScript, where you cannot write JSX.
+  - `h` can be useful when using Uppy from plain JavaScript, where you cannot
+    write JSX.
 
 <details>
 <summary>Example: meta fields configured as an `Array`</summary>
@@ -315,68 +380,86 @@ uppy.use(Dashboard, {
 
 #### `closeModalOnClickOutside`
 
-Set to true to automatically close the modal when the user clicks outside of it (`boolean`, default: `false`).
+Set to true to automatically close the modal when the user clicks outside of it
+(`boolean`, default: `false`).
 
 #### `closeAfterFinish`
 
-Set to true to automatically close the modal when all current uploads are complete (`boolean`, default: `false`).
+Set to true to automatically close the modal when all current uploads are
+complete (`boolean`, default: `false`).
 
-With this option, the modal is only automatically closed when uploads are complete _and successful_.
-If some uploads failed, the modal stays open so the user can retry failed uploads or cancel the current batch and upload an entirely different set of files instead.
+With this option, the modal is only automatically closed when uploads are
+complete _and successful_. If some uploads failed, the modal stays open so the
+user can retry failed uploads or cancel the current batch and upload an entirely
+different set of files instead.
 
 :::info
-You can use this together with the [`allowMultipleUploads: false`](/docs/uppy-core/#allowmultipleuploads) option in Uppy Core
-to create a smooth experience when uploading a single (batch of) file(s).
 
-This is recommended. With several upload batches, the auto-closing behavior can be quite confusing for users.
+You can use this together with the
+[`allowMultipleUploads: false`](/docs/uppy-core/#allowmultipleuploads) option in
+Uppy Core to create a smooth experience when uploading a single (batch of)
+file(s).
+
+This is recommended. With several upload batches, the auto-closing behavior can
+be quite confusing for users.
+
 :::
 
 #### `disablePageScrollWhenModalOpen`
 
 Disable page scroll when the modal is open (`boolean`, default: `true`).
 
-Page scrolling is disabled by default when the Dashboard modal is open, so when you scroll a list of files in Uppy,
-the website in the background stays still.
+Page scrolling is disabled by default when the Dashboard modal is open, so when
+you scroll a list of files in Uppy, the website in the background stays still.
 Set to false to override this behaviour and leave page scrolling intact.
 
 #### `animateOpenClose`
 
-Add animations when the modal dialog is opened or closed, for a more satisfying user experience (`boolean`, default: `true`).
+Add animations when the modal dialog is opened or closed, for a more satisfying
+user experience (`boolean`, default: `true`).
 
 #### `fileManagerSelectionType`
 
-Configure the type of selections allowed when browsing your file system via the file manager selection window (`string`, default: `'files'`).
+Configure the type of selections allowed when browsing your file system via the
+file manager selection window (`string`, default: `'files'`).
 
-May be either `'files'`, `'folders'`, or `'both'`.
-Selecting entire folders for upload may not be supported on all [browsers](https://caniuse.com/#feat=input-file-directory).
+May be either `'files'`, `'folders'`, or `'both'`. Selecting entire folders for
+upload may not be supported on all
+[browsers](https://caniuse.com/#feat=input-file-directory).
 
 #### `proudlyDisplayPoweredByUppy`
 
 Show the Uppy logo with a link (`boolean`, default: `true`).
 
-Uppy is provided to the world for free by the team behind [Transloadit](https://transloadit.com).
-In return, we ask that you consider keeping a tiny Uppy logo at the bottom of the Dashboard, so that more people can discover and use Uppy.
+Uppy is provided to the world for free by the team behind
+[Transloadit](https://transloadit.com). In return, we ask that you consider
+keeping a tiny Uppy logo at the bottom of the Dashboard, so that more people can
+discover and use Uppy.
 
 #### `disableStatusBar`
 
 Disable the status bar completely (`boolean`, default: `false`).
 
-Dashboard ships with the `StatusBar` plugin that shows upload progress and pause/resume/cancel buttons.
-If you want, you can disable the StatusBar to provide your own custom solution.
+Dashboard ships with the `StatusBar` plugin that shows upload progress and
+pause/resume/cancel buttons. If you want, you can disable the StatusBar to
+provide your own custom solution.
 
 #### `disableInformer: false`
 
-Disable informer (shows notifications in the form of toasts) completely (`boolean`, default: `false`).
+Disable informer (shows notifications in the form of toasts) completely
+(`boolean`, default: `false`).
 
-Dashboard ships with the `Informer` plugin that notifies when the browser is offline, or when it’s time to say cheese if `Webcam` is taking a picture.
-If you want, you can disable the Informer and/or provide your own custom solution.
+Dashboard ships with the `Informer` plugin that notifies when the browser is
+offline, or when it’s time to say cheese if `Webcam` is taking a picture. If you
+want, you can disable the Informer and/or provide your own custom solution.
 
 #### `disableThumbnailGenerator`
 
 Disable the thumbnail generator completely (`boolean`, default: `false`).
 
-Dashboard ships with the `ThumbnailGenerator` plugin that adds small resized image thumbnails to images, for preview purposes only.
-If you want, you can disable the `ThumbnailGenerator` and/or provide your own custom solution.
+Dashboard ships with the `ThumbnailGenerator` plugin that adds small resized
+image thumbnails to images, for preview purposes only. If you want, you can
+disable the `ThumbnailGenerator` and/or provide your own custom solution.
 
 #### `locale`
 
@@ -475,7 +558,8 @@ module.exports = {
 
 Light or dark theme for the Dashboard (`string`, default: `'light'`).
 
-Uppy Dashboard supports “Dark Mode”. You can try it live on [the Dashboard example page](https://uppy.io/examples/dashboard/).
+Uppy Dashboard supports “Dark Mode”. You can try it live on
+[the Dashboard example page](https://uppy.io/examples/dashboard/).
 
 It supports the following values:
 
@@ -485,17 +569,22 @@ It supports the following values:
 
 #### `autoOpenFileEditor`
 
-Automatically open file editor (see [`@uppy/image-editor`](/docs/user-interfaces/elements/image-editor/)) for the first file in a batch (`boolean`, default: `false`).
+Automatically open file editor (see
+[`@uppy/image-editor`](/docs/user-interfaces/elements/image-editor/)) for the
+first file in a batch (`boolean`, default: `false`).
 
-If one file is added, editor opens for that file, if 10 files are added — editor opens for the first file.
-Use case: user adds an image — Uppy opens Image Editor right away — user crops / adjusts the image — upload.
+If one file is added, editor opens for that file, if 10 files are added — editor
+opens for the first file. Use case: user adds an image — Uppy opens Image Editor
+right away — user crops / adjusts the image — upload.
 
 #### `disabled`
 
-Enabling this option makes the Dashboard grayed-out and non-interactive (`boolean`, default: `false`).
+Enabling this option makes the Dashboard grayed-out and non-interactive
+(`boolean`, default: `false`).
 
-Users won’t be able to click on buttons or drop files.
-Useful when you need to conditionally enable/disable file uploading or manipulation, based on a condition in your app. Can be set on init or via API:
+Users won’t be able to click on buttons or drop files. Useful when you need to
+conditionally enable/disable file uploading or manipulation, based on a
+condition in your app. Can be set on init or via API:
 
 ```js
 const dashboard = uppy.getPlugin('Dashboard');
@@ -510,8 +599,9 @@ userNameInput.addEventListener('change', () => {
 
 Disable local files (`boolean`, default: `false`).
 
-Enabling this option will disable drag & drop, hide the “browse” and “My Device” button,
-allowing only uploads from plugins, such as Webcam, Screen Capture, Google Drive, Instagram.
+Enabling this option will disable drag & drop, hide the “browse” and “My Device”
+button, allowing only uploads from plugins, such as Webcam, Screen Capture,
+Google Drive, Instagram.
 
 #### `onDragOver(event)`
 
@@ -528,7 +618,11 @@ Callback for the [`ondragleave`][ondragleave] event handler.
 ### Methods
 
 :::info
-Dashboard also has the methods described in [`UIPlugin`](/docs/uppy-core#new-uipluginuppy-options) and [`BasePlugin`](/docs/uppy-core#new-basepluginuppy-options).
+
+Dashboard also has the methods described in
+[`UIPlugin`](/docs/uppy-core#new-uipluginuppy-options) and
+[`BasePlugin`](/docs/uppy-core#new-basepluginuppy-options).
+
 :::
 
 #### `openModal()`
@@ -557,7 +651,10 @@ if (dashboard.isModalOpen()) {
 ### Events
 
 :::info
-You can use [`on`](/docs/uppy-core#onevent-action) and [`once`](/docs/uppy-core#onceevent-action) to listen to these events.
+
+You can use [`on`](/docs/uppy-core#onevent-action) and
+[`once`](/docs/uppy-core#onceevent-action) to listen to these events.
+
 :::
 
 #### `dashboard:modal-open`
@@ -578,52 +675,77 @@ Fired when the Dashboard modal is closed.
 
 **Parameters:**
 
-- `file` — The [File Object](https://uppy.io/docs/uppy/#File-Objects) representing the file that was opened for editing.
+- `file` — The [File Object](https://uppy.io/docs/uppy/#File-Objects)
+  representing the file that was opened for editing.
 
-Fired when the user clicks “edit” icon next to a file in the Dashboard. The FileCard panel is then open with file metadata available for editing.
+Fired when the user clicks “edit” icon next to a file in the Dashboard. The
+FileCard panel is then open with file metadata available for editing.
 
 #### `dashboard:file-edit-complete`
 
 **Parameters:**
 
-- `file` — The [File Object](https://uppy.io/docs/uppy/#File-Objects) representing the file that was edited.
+- `file` — The [File Object](https://uppy.io/docs/uppy/#File-Objects)
+  representing the file that was edited.
 
 Fired when the user finished editing the file metadata.
 
 ## Integrations
 
-These are the plugins specifically made for the Dashboard.
-This is not a list of all Uppy plugins.
+These are the plugins specifically made for the Dashboard. This is not a list of
+all Uppy plugins.
 
 ### Sources
 
 - [`@uppy/audio`](/docs/sources/audio) — record audio.
-- [`@uppy/box`](/docs/sources/companion-plugins/box) — import files from [Box](https://www.box.com/en-nl/home).
-- [`@uppy/dropbox`](/docs/sources/companion-plugins/dropbox) — import from [Dropbox](https://dropbox.com).
-- [`@uppy/facebook`](/docs/sources/companion-plugins/dropbox) — import from [Facebook](https://facebook.com).
-- [`@uppy/google-drive`](/docs/sources/companion-plugins/google-drive) — import from [Google Drive](https://drive.google.com).
-- [`@uppy/instagram`](/docs/sources/companion-plugins/instagram) — import from [Instagram](https://instagram.com).
-- [`@uppy/onedrive`](/docs/sources/companion-plugins/onedrive) — import from [OneDrive](https://www.microsoft.com/en-us/microsoft-365/onedrive/online-cloud-storage).
-- [`@uppy/screen-capture`](/docs/sources/screen-capture) — Record your screen, including (optionally) your microphone.
-- [`@uppy/unsplash`](/docs/sources/companion-plugins/unsplash) — import files from [Unsplash](https://unsplash.com/)
-- [`@uppy/url`](/docs/sources/companion-plugins/url) — import files from any URL.
-- [`@uppy/webcam`](/docs/sources/webcam) — Record or make a picture with your webcam.
-- [`@uppy/zoom`](/docs/sources/companion-plugins/url) — import files from [Zoom](https://zoom.us).
+- [`@uppy/box`](/docs/sources/companion-plugins/box) — import files from
+  [Box](https://www.box.com/en-nl/home).
+- [`@uppy/dropbox`](/docs/sources/companion-plugins/dropbox) — import from
+  [Dropbox](https://dropbox.com).
+- [`@uppy/facebook`](/docs/sources/companion-plugins/dropbox) — import from
+  [Facebook](https://facebook.com).
+- [`@uppy/google-drive`](/docs/sources/companion-plugins/google-drive) — import
+  from [Google Drive](https://drive.google.com).
+- [`@uppy/instagram`](/docs/sources/companion-plugins/instagram) — import from
+  [Instagram](https://instagram.com).
+- [`@uppy/onedrive`](/docs/sources/companion-plugins/onedrive) — import from
+  [OneDrive](https://www.microsoft.com/en-us/microsoft-365/onedrive/online-cloud-storage).
+- [`@uppy/screen-capture`](/docs/sources/screen-capture) — Record your screen,
+  including (optionally) your microphone.
+- [`@uppy/unsplash`](/docs/sources/companion-plugins/unsplash) — import files
+  from [Unsplash](https://unsplash.com/)
+- [`@uppy/url`](/docs/sources/companion-plugins/url) — import files from any
+  URL.
+- [`@uppy/webcam`](/docs/sources/webcam) — Record or make a picture with your
+  webcam.
+- [`@uppy/zoom`](/docs/sources/companion-plugins/url) — import files from
+  [Zoom](https://zoom.us).
 
 ### UI
 
-- [`@uppy/image-editor`](/docs/user-interfaces/elements/image-editor) — allows users to crop, rotate, zoom and flip images that are added to Uppy.
-- [`@uppy/informer`](/docs/user-interfaces/elements/informer) — show notifications.
-- [`@uppy/status-bar`](/docs/user-interfaces/elements/status-bar) — advanced upload progress status bar.
-- [`@uppy/thumbnail-generator`](/docs/user-interfaces/elements/thumbnail-generator) — generate preview thumbnails for images to be uploaded.
+- [`@uppy/image-editor`](/docs/user-interfaces/elements/image-editor) — allows
+  users to crop, rotate, zoom and flip images that are added to Uppy.
+- [`@uppy/informer`](/docs/user-interfaces/elements/informer) — show
+  notifications.
+- [`@uppy/status-bar`](/docs/user-interfaces/elements/status-bar) — advanced
+  upload progress status bar.
+- [`@uppy/thumbnail-generator`](/docs/user-interfaces/elements/thumbnail-generator)
+  — generate preview thumbnails for images to be uploaded.
 
 ### Frameworks
 
-- [`@uppy/angular`](/docs/framework-integrations/angular) — Dashboard component for [Angular](https://angular.io/).
-- [`@uppy/react`](/docs/framework-integrations/react) — Dashboard component for [React](https://reactjs.org/).
-- [`@uppy/svelte`](/docs/framework-integrations/svelte) — Dashboard component for [Svelte](https://svelte.dev/).
-- [`@uppy/vue`](/docs/framework-integrations/vue) — Dashboard component for [Vue](https://vuejs.org/).
+- [`@uppy/angular`](/docs/framework-integrations/angular) — Dashboard component
+  for [Angular](https://angular.io/).
+- [`@uppy/react`](/docs/framework-integrations/react) — Dashboard component for
+  [React](https://reactjs.org/).
+- [`@uppy/svelte`](/docs/framework-integrations/svelte) — Dashboard component
+  for [Svelte](https://svelte.dev/).
+- [`@uppy/vue`](/docs/framework-integrations/vue) — Dashboard component for
+  [Vue](https://vuejs.org/).
 
-[ondragover]: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/ondragover
-[ondragleave]: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/ondragleave
-[ondrop]: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/ondrop
+[ondragover]:
+	https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/ondragover
+[ondragleave]:
+	https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/ondragleave
+[ondrop]:
+	https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/ondrop

--- a/docs/user-interfaces/drag-drop.mdx
+++ b/docs/user-interfaces/drag-drop.mdx
@@ -12,14 +12,18 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 The `@uppy/drag-drop` plugin renders a drag and drop area for file selection.
 
 :::tip
-[Try out the live example](/examples) or take it for a spin in [CodeSandbox](https://codesandbox.io/s/uppy-drag-drop-gyewzx?file=/src/index.js).
+
+[Try out the live example](/examples) or take it for a spin in
+[CodeSandbox](https://codesandbox.io/s/uppy-drag-drop-gyewzx?file=/src/index.js).
+
 :::
 
 ## When should I use this?
 
-It can be useful when you only want the local device as a file source, don’t need file previews and a UI for metadata editing,
-or the [Dashboard](/docs/dashboard/) is too much. But it can be too minimal too.
-By default it doesn’t show that a file has been added nor is there a progress bar.
+It can be useful when you only want the local device as a file source, don’t
+need file previews and a UI for metadata editing, or the
+[Dashboard](/docs/dashboard/) is too much. But it can be too minimal too. By
+default it doesn’t show that a file has been added nor is there a progress bar.
 
 ## Install
 
@@ -64,9 +68,13 @@ new Uppy().use(DragDrop, { target: '#drag-drop' });
 ```
 
 :::info
-Certain [restrictions](/docs/uppy#restrictions) set in Uppy’s options, namely `maxNumberOfFiles` and `allowedFileTypes`,
-affect the system file picker dialog. If `maxNumberOfFiles: 1`, users will only be able to select one file,
-and `allowedFileTypes: ['video/*', '.gif']` means only videos or gifs (files with `.gif` extension) will be selectable.
+
+Certain [restrictions](/docs/uppy#restrictions) set in Uppy’s options, namely
+`maxNumberOfFiles` and `allowedFileTypes`, affect the system file picker dialog.
+If `maxNumberOfFiles: 1`, users will only be able to select one file, and
+`allowedFileTypes: ['video/*', '.gif']` means only videos or gifs (files with
+`.gif` extension) will be selectable.
+
 :::
 
 ## API
@@ -81,25 +89,30 @@ Use this if you need to add several DragDrop instances.
 
 #### `target`
 
-DOM element, CSS selector, or plugin to place the drag and drop area into (`string` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to place the drag and drop area into
+(`string` or `Element`, default: `null`).
 
 #### `width`
 
 Drag and drop area width (`string`, default: `'100%'`).
 
-Set in inline CSS, so feel free to use percentage, pixels or other values that you like.
+Set in inline CSS, so feel free to use percentage, pixels or other values that
+you like.
 
 #### `height`
 
 Drag and drop area height (`string`, default: `'100%'`).
 
-Set in inline CSS, so feel free to use percentage, pixels or other values that you like.
+Set in inline CSS, so feel free to use percentage, pixels or other values that
+you like.
 
 #### `note`
 
-Optionally, specify a string of text that explains something about the upload for the user (`string`, default: `null`).
+Optionally, specify a string of text that explains something about the upload
+for the user (`string`, default: `null`).
 
-This is a place to explain any `restrictions` that are put in place. For example: `'Images and video only, 2–3 files, up to 1 MB'`.
+This is a place to explain any `restrictions` that are put in place. For
+example: `'Images and video only, 2–3 files, up to 1 MB'`.
 
 #### `locale`
 
@@ -127,6 +140,9 @@ Callback for the [`ondragleave`][ondragleave] event handler.
 
 Callback for the [`ondrop`][ondrop] event handler.
 
-[ondragover]: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/ondragover
-[ondragleave]: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/ondragleave
-[ondrop]: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/ondrop
+[ondragover]:
+	https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/ondragover
+[ondragleave]:
+	https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/ondragleave
+[ondrop]:
+	https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/ondrop

--- a/docs/user-interfaces/elements/image-editor.mdx
+++ b/docs/user-interfaces/elements/image-editor.mdx
@@ -19,7 +19,8 @@ Image editor. Designed to be used with the Dashboard UI.
 
 ## When should I use this?
 
-When you want to allow users to crop, rotate, zoom and flip images that are added to Uppy.
+When you want to allow users to crop, rotate, zoom and flip images that are
+added to Uppy.
 
 ## Install
 
@@ -73,8 +74,11 @@ new Uppy()
 ### Options
 
 :::info
-If you automatically want to open the image editor when an image is added,
-see the [`autoOpenFileEditor`](/docs/user-interfaces/dashboard#autoOpenFileEditor) Dashboard option.
+
+If you automatically want to open the image editor when an image is added, see
+the [`autoOpenFileEditor`](/docs/user-interfaces/dashboard#autoOpenFileEditor)
+Dashboard option.
+
 :::
 
 #### `id`
@@ -83,21 +87,25 @@ A unique identifier for this plugin (`string`, default: `'ImageEditor'`).
 
 #### `quality`
 
-Quality Of the resulting blob that will be saved in Uppy after editing/cropping (`number`, default: `0.8`).
+Quality Of the resulting blob that will be saved in Uppy after editing/cropping
+(`number`, default: `0.8`).
 
 #### `cropperOptions`
 
-Image Editor is using the excellent [Cropper.js](https://fengyuanchen.github.io/cropperjs/).
-`cropperOptions` will be directly passed to `Cropper` and therefor can expect the same values as documented
-in their [README](https://github.com/fengyuanchen/cropperjs/blob/HEAD/README.md#options),
-with the addition of `croppedCanvasOptions`, which will be passed to [`getCroppedCanvas`](https://github.com/fengyuanchen/cropperjs/blob/HEAD/README.md#getcroppedcanvasoptions).
+Image Editor is using the excellent
+[Cropper.js](https://fengyuanchen.github.io/cropperjs/). `cropperOptions` will
+be directly passed to `Cropper` and therefor can expect the same values as
+documented in their
+[README](https://github.com/fengyuanchen/cropperjs/blob/HEAD/README.md#options),
+with the addition of `croppedCanvasOptions`, which will be passed to
+[`getCroppedCanvas`](https://github.com/fengyuanchen/cropperjs/blob/HEAD/README.md#getcroppedcanvasoptions).
 
 #### `actions`
 
 Shown action buttons (`Object` or `boolean`).
 
-If you you’d like to hide all actions, pass `false` to it. By default all the actions are visible.
-Or enable/disable them individually:
+If you you’d like to hide all actions, pass `false` to it. By default all the
+actions are visible. Or enable/disable them individually:
 
 ```js
 {
@@ -133,7 +141,10 @@ export default {
 ### Events
 
 :::info
-You can use [`on`](/docs/uppy-core#onevent-action) and [`once`](/docs/uppy-core#onceevent-action) to listen to these events.
+
+You can use [`on`](/docs/uppy-core#onevent-action) and
+[`once`](/docs/uppy-core#onceevent-action) to listen to these events.
+
 :::
 
 #### `file-editor:start`
@@ -158,7 +169,8 @@ uppy.on('file-editor:complete', (updatedFile) => {
 
 #### `file-editor:cancel`
 
-Emitted when `uninstall` is called or when the current image editing changes are discarded.
+Emitted when `uninstall` is called or when the current image editing changes are
+discarded.
 
 ```js
 uppy.on('file-editor:cancel', (file) => {

--- a/docs/user-interfaces/elements/informer.mdx
+++ b/docs/user-interfaces/elements/informer.mdx
@@ -9,14 +9,16 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # Informer
 
-The `@uppy/informer` plugin is a pop-up bar for showing notifications for the [Dashboard](/docs/user-interfaces/dashboard).
-When plugins have some exciting news (or errors) to share, they can with Informer
+The `@uppy/informer` plugin is a pop-up bar for showing notifications for the
+[Dashboard](/docs/user-interfaces/dashboard). When plugins have some exciting
+news (or errors) to share, they can with Informer
 
 ## When should I use it?
 
-When you use the [Dashboard](/docs/user-interfaces/dashboard) it’s already included by default.
-This plugin is published separately but made specifically for the Dashboard.
-You can technically use it without it, but it’s not officially supported.
+When you use the [Dashboard](/docs/user-interfaces/dashboard) it’s already
+included by default. This plugin is published separately but made specifically
+for the Dashboard. You can technically use it without it, but it’s not
+officially supported.
 
 ## Install
 
@@ -62,8 +64,8 @@ import '@uppy/informer/dist/style.min.css';
 new Uppy().use(Informer, { target: '#informer' });
 ```
 
-Informer gets its data from `uppy.state.info`,
-which is updated by various plugins via [`uppy.info`](/docs/uppy-core#infomessage-type-duration) method.
+Informer gets its data from `uppy.state.info`, which is updated by various
+plugins via [`uppy.info`](/docs/uppy-core#infomessage-type-duration) method.
 
 In the [compressor](/docs/compressor) plugin we use it like this for instance:
 
@@ -72,8 +74,9 @@ const size = prettierBytes(totalCompressedSize);
 this.uppy.info(this.i18n('compressedX', { size }), 'info');
 ```
 
-When calling `uppy.info`, [Uppy](/docs/uppy-core) emits [`info-visible`](/docs/uppy-core#info-visible)
-and will emit [`info-hidden`](/docs/uppy-core#info-hidden) after the timeout.
+When calling `uppy.info`, [Uppy](/docs/uppy-core) emits
+[`info-visible`](/docs/uppy-core#info-visible) and will emit
+[`info-hidden`](/docs/uppy-core#info-hidden) after the timeout.
 
 ## API
 
@@ -87,4 +90,5 @@ Use this if you need several `Informer` instances.
 
 ### `target`
 
-DOM element, CSS selector, or plugin to mount the Informer into (`string` or `Element`, default: `null`).
+DOM element, CSS selector, or plugin to mount the Informer into (`string` or
+`Element`, default: `null`).

--- a/docs/user-interfaces/elements/progress-bar.mdx
+++ b/docs/user-interfaces/elements/progress-bar.mdx
@@ -9,14 +9,18 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # Progress bar
 
-`@uppy/progress-bar` is a minimalist plugin that shows the current upload progress in a thin bar element,
-like the ones used by YouTube and GitHub when navigating between pages.
+`@uppy/progress-bar` is a minimalist plugin that shows the current upload
+progress in a thin bar element, like the ones used by YouTube and GitHub when
+navigating between pages.
 
 ## When should I use it?
 
-When you need a minimalistec progress indicator and you’re [building your own UI](/docs/guides/building-your-own-ui-with-uppy).
-For most cases, [Dashboard](/docs/user-interfaces/dashboard) or [Drag & Drop](/docs/user-interfaces/drag-drop)
-(with [Status Bar](/docs/user-interfaces/elements/status-bar)) is more likely what you need.
+When you need a minimalistec progress indicator and you’re
+[building your own UI](/docs/guides/building-your-own-ui-with-uppy). For most
+cases, [Dashboard](/docs/user-interfaces/dashboard) or
+[Drag & Drop](/docs/user-interfaces/drag-drop) (with
+[Status Bar](/docs/user-interfaces/elements/status-bar)) is more likely what you
+need.
 
 ## Install
 
@@ -72,14 +76,17 @@ Use this if you need to add several ProgressBar instances.
 
 #### `target`
 
-DOM element, CSS selector, or plugin to mount the Status Bar into (`Element`, `string`, default: `null`).
+DOM element, CSS selector, or plugin to mount the Status Bar into (`Element`,
+`string`, default: `null`).
 
 #### `fixed`
 
-Show the progress bar at the top of the page with `position: fixed` (`boolean`, default: `false`).
+Show the progress bar at the top of the page with `position: fixed` (`boolean`,
+default: `false`).
 
 When set to false, show the progress bar inline wherever it’s mounted.
 
 #### `hideAfterFinish`
 
-Hides the progress bar after the upload has finished (`boolean`, default: `true`).
+Hides the progress bar after the upload has finished (`boolean`, default:
+`true`).

--- a/docs/user-interfaces/elements/status-bar.mdx
+++ b/docs/user-interfaces/elements/status-bar.mdx
@@ -9,19 +9,23 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # Status bar
 
-The `@uppy/status-bar` plugin shows upload progress and speed, estimated time, pre- and post-processing information,
-and allows users to control (pause/resume/cancel) the upload.
+The `@uppy/status-bar` plugin shows upload progress and speed, estimated time,
+pre- and post-processing information, and allows users to control
+(pause/resume/cancel) the upload.
 
 :::tip
-Try it out together with [`@uppy/drag-drop`](/docs/user-interfaces/drag-drop)
-in [CodeSandbox](https://codesandbox.io/s/uppy-drag-drop-gyewzx?file=/src/index.js)
+
+Try it out together with [`@uppy/drag-drop`](/docs/user-interfaces/drag-drop) in
+[CodeSandbox](https://codesandbox.io/s/uppy-drag-drop-gyewzx?file=/src/index.js)
+
 :::
 
 ## When should I use it?
 
-When you use the [Dashboard](/docs/user-interfaces/dashboard) it’s already included by default.
-This plugin is published separately but made specifically for the Dashboard.
-You can still use it without it but it may need some (CSS) tweaking for your use case.
+When you use the [Dashboard](/docs/user-interfaces/dashboard) it’s already
+included by default. This plugin is published separately but made specifically
+for the Dashboard. You can still use it without it but it may need some (CSS)
+tweaking for your use case.
 
 ## Install
 
@@ -77,7 +81,8 @@ Use this if you need to add several StatusBar instances.
 
 #### `target`
 
-DOM element, CSS selector, or plugin to mount the Status Bar into (`Element`, `string`, `UIPlugin`, default: `'body'`).
+DOM element, CSS selector, or plugin to mount the Status Bar into (`Element`,
+`string`, `UIPlugin`, default: `'body'`).
 
 #### `hideAfterFinish`
 
@@ -88,41 +93,50 @@ Hide the Status Bar after the upload is complete (`boolean`, default: `true`).
 Display remaining upload size and estimated time (`boolean`, default: `false`)
 
 :::note
+
 `false`: Uploading: 45%
 
 `true`: Uploading: 45%・43 MB of 101 MB・8s left
+
 :::
 
 #### `hideUploadButton`
 
 Hide the upload button (`boolean`, default: `false`).
 
-Use this if you are providing a custom upload button somewhere, and using the `uppy.upload()` API.
+Use this if you are providing a custom upload button somewhere, and using the
+`uppy.upload()` API.
 
 #### `hideRetryButton`
 
 Hide the retry button (`boolean`, default: `false`).
 
-Use this if you are providing a custom retry button somewhere, and using the `uppy.retryAll()` or `uppy.retryUpload(fileID)` API.
+Use this if you are providing a custom retry button somewhere, and using the
+`uppy.retryAll()` or `uppy.retryUpload(fileID)` API.
 
 #### `hidePauseResumeButton`
 
-Hide pause/resume buttons (for resumable uploads, via [tus](http://tus.io), for example) (`boolean`, default: `false`).
+Hide pause/resume buttons (for resumable uploads, via [tus](http://tus.io), for
+example) (`boolean`, default: `false`).
 
-Use this if you are providing custom cancel or pause/resume buttons somewhere, and using the `uppy.pauseResume(fileID)` or `uppy.removeFile(fileID)` API.
+Use this if you are providing custom cancel or pause/resume buttons somewhere,
+and using the `uppy.pauseResume(fileID)` or `uppy.removeFile(fileID)` API.
 
 #### `hideCancelButton`
 
 Hide the cancel button (`boolean`, default: `false`).
 
-Use this if you are providing a custom retry button somewhere, and using the `uppy.cancelAll()` API.
+Use this if you are providing a custom retry button somewhere, and using the
+`uppy.cancelAll()` API.
 
 #### `doneButtonHandler`
 
-Status Bar will render a “Done” button in place of pause/resume/cancel buttons, once the upload/encoding is done (`Function`, default: `null`).
+Status Bar will render a “Done” button in place of pause/resume/cancel buttons,
+once the upload/encoding is done (`Function`, default: `null`).
 
-The behaviour of this “Done” button is defined by the handler function — can be used to close file picker modals or clear the upload state.
-This is what the Dashboard plugin, which uses Status Bar internally, sets:
+The behaviour of this “Done” button is defined by the handler function — can be
+used to close file picker modals or clear the upload state. This is what the
+Dashboard plugin, which uses Status Bar internally, sets:
 
 ```js
 const doneButtonHandler = () => {

--- a/docs/user-interfaces/elements/thumbnail-generator.mdx
+++ b/docs/user-interfaces/elements/thumbnail-generator.mdx
@@ -9,16 +9,22 @@ import UppyCdnExample from '/src/components/UppyCdnExample';
 
 # Thumbnail generator
 
-`@uppy/thumbnail-generator` generates proportional thumbnails (file previews) for images that are added to Uppy.
+`@uppy/thumbnail-generator` generates proportional thumbnails (file previews)
+for images that are added to Uppy.
 
 ## When should I use this?
 
-This plugin is included by default with the [Dashboard](/docs/user-interfaces/dashboard) plugin, and can also be useful to display image previews in a custom UI.
+This plugin is included by default with the
+[Dashboard](/docs/user-interfaces/dashboard) plugin, and can also be useful to
+display image previews in a custom UI.
 
 :::note
-Thumbnails are only generated for _local_ files.
-Remote files through [Companion](/docs/companion) generally won’t have thumbnails because they are downloaded on the server.
-Some providers, such as Google Drive, have baked in thumbnails into their API responses.
+
+Thumbnails are only generated for _local_ files. Remote files through
+[Companion](/docs/companion) generally won’t have thumbnails because they are
+downloaded on the server. Some providers, such as Google Drive, have baked in
+thumbnails into their API responses.
+
 :::
 
 ## Install
@@ -53,8 +59,8 @@ yarn add @uppy/thumbnail-generator
 
 ## Use
 
-If you use the [Dashboard](/docs/user-interfaces/dashboard) then it’s already installed.
-If you want to use it programatically for your own UI:
+If you use the [Dashboard](/docs/user-interfaces/dashboard) then it’s already
+installed. If you want to use it programatically for your own UI:
 
 ```js showLineNumbers
 import Uppy from '@uppy/core';
@@ -88,51 +94,64 @@ export default {
 
 Width of the resulting thumbnail (`number`, default: `200`).
 
-Thumbnails are always proportional and not cropped.
-If width is provided, height is calculated automatically to match ratio.
-If both width and height are given, only width is taken into account.
+Thumbnails are always proportional and not cropped. If width is provided, height
+is calculated automatically to match ratio. If both width and height are given,
+only width is taken into account.
 
 #### `thumbnailHeight`
 
 Height of the resulting thumbnail (`number`, default: `200`).
 
-Thumbnails are always proportional and not cropped.
-If height is provided, width is calculated automatically to match ratio.
-If both width and height are given, only width is taken into account.
+Thumbnails are always proportional and not cropped. If height is provided, width
+is calculated automatically to match ratio. If both width and height are given,
+only width is taken into account.
 
 :::note
+
 Produce a 300px height thumbnail with calculated width to match ratio:
 
 ```js
 uppy.use(ThumbnailGenerator, { thumbnailHeight: 300 });
 ```
 
-Produce a 300px width thumbnail with calculated height to match ratio (and ignore the given height):
+Produce a 300px width thumbnail with calculated height to match ratio (and
+ignore the given height):
 
 ```js
 uppy.use(ThumbnailGenerator, { thumbnailWidth: 300, thumbnailHeight: 300 });
 ```
 
-See issue [#979](https://github.com/transloadit/uppy/issues/979) and [#1096](https://github.com/transloadit/uppy/pull/1096) for details on this feature.
+See issue [#979](https://github.com/transloadit/uppy/issues/979) and
+[#1096](https://github.com/transloadit/uppy/pull/1096) for details on this
+feature.
+
 :::
 
 #### `thumbnailType`
 
 MIME type of the resulting thumbnail (`string`, default: `'image/jpeg'`).
 
-This is useful if you want to support transparency in your thumbnails by switching to `image/png`.
+This is useful if you want to support transparency in your thumbnails by
+switching to `image/png`.
 
 #### `waitForThumbnailsBeforeUpload`
 
-Whether to wait for all thumbnails to be ready before starting the upload (`boolean`, default: `false`).
+Whether to wait for all thumbnails to be ready before starting the upload
+(`boolean`, default: `false`).
 
-If set to `true`, Thumbnail Generator will invoke Uppy’s internal processing stage and wait for `thumbnail:all-generated` event, before proceeding to the uploading stage.
-This is useful because Thumbnail Generator also adds EXIF data to images, and if we wait until it’s done processing, this data will be available on the server after the upload.
+If set to `true`, Thumbnail Generator will invoke Uppy’s internal processing
+stage and wait for `thumbnail:all-generated` event, before proceeding to the
+uploading stage. This is useful because Thumbnail Generator also adds EXIF data
+to images, and if we wait until it’s done processing, this data will be
+available on the server after the upload.
 
 ### Events
 
 :::info
-You can use [`on`](/docs/uppy-core#onevent-action) and [`once`](/docs/uppy-core#onceevent-action) to listen to these events.
+
+You can use [`on`](/docs/uppy-core#onevent-action) and
+[`once`](/docs/uppy-core#onceevent-action) to listen to these events.
+
 :::
 
 #### `thumbnail:generated`


### PR DESCRIPTION
This option ensures the test inside MD(x) files stays under 80 chars of length, improving the readability and minifying diffs.

Note that 80 is the default, we can override it with another value if we feel 80 is not appropriate.