### PR TITLE
meta: make commit hooks use `yarn` instead of `npx`

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged --allow-empty
+corepack yarn lint-staged --allow-empty


### PR DESCRIPTION
And make it work for folks who don't have npm installed on their workstation :)