### PR TITLE
Fix plugin environment variable names

### DIFF
--- a/docs/sources/companion-plugins/instagram.mdx
+++ b/docs/sources/companion-plugins/instagram.mdx
@@ -101,8 +101,8 @@ Configure the Instagram key and secret in Companion. With the standalone
 Companion server, specify environment variables:
 
 ```shell
-export COMPANION_GOOGLE_KEY="Instagram OAuth client ID"
-export COMPANION_GOOGLE_SECRET="Instagram OAuth client secret"
+export COMPANION_INSTAGRAM_KEY="Instagram OAuth client ID"
+export COMPANION_INSTAGRAM_SECRET="Instagram OAuth client secret"
 ```
 
 When using the Companion Node.js API, configure these options:

--- a/docs/sources/companion-plugins/onedrive.mdx
+++ b/docs/sources/companion-plugins/onedrive.mdx
@@ -101,8 +101,8 @@ Configure the OneDrive key and secret in Companion. With the standalone
 Companion server, specify environment variables:
 
 ```shell
-export COMPANION_GOOGLE_KEY="OneDrive OAuth client ID"
-export COMPANION_GOOGLE_SECRET="OneDrive OAuth client secret"
+export COMPANION_ONEDRIVE_KEY="OneDrive OAuth client ID"
+export COMPANION_ONEDRIVE_SECRET="OneDrive OAuth client secret"
 ```
 
 When using the Companion Node.js API, configure these options:


### PR DESCRIPTION
In the Companion docs, the Instagram and OneDrive plugins specified Google plugin environment variables. This PR fixes those env var references.