### PR TITLE
Consistent typography

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -92,6 +92,12 @@
 	--ifm-avatar-intro-margin: 0.5rem;
 }
 
+@media screen and (min-width: 1000px) and (max-width: 1300px) {
+	:root {
+		--ifm-font-size-base: 16px;
+	}
+}
+
 h1 {
 	margin-top: calc(var(--ifm-h1-vertical-rhythm-top) * var(--ifm-leading) / 2);
 }
@@ -144,44 +150,18 @@ div[class*=' admonitionHeading'] {
 
 /* Blog */
 
-/* .avatar__name {
-	font: 500 var(--ifm-h4-font-size)/var(--ifm-heading-line-height) var(--ifm-font-family-base);
-} */
-
 .avatar__name {
-	font-size: 0.75rem;
 	font-weight: 500;
 }
 
 h1[itemprop='headline'] {
-	font-size: 1.8rem;
+	font-size: 2.4rem;
 	margin-bottom: 0.6rem;
 }
 
 h2[itemprop='headline'] {
-	font-size: 1.5rem;
+	font-size: 2.4rem;
 	margin-bottom: 0.6rem;
-}
-
-.theme-edit-this-page {
-	font-size: 0.75rem;
-}
-
-.theme-edit-this-page svg {
-	width: 13px;
-	height: 13px;
-}
-
-.blog__post-footer__follow {
-	list-style: none;
-	padding: 0;
-	margin: 0;
-	font-size: 0.9rem;
-	text-align: left;
-}
-
-.blog__post-footer__follow li {
-	margin-bottom: 10px;
 }
 
 /* Content Body */

--- a/src/pages/examples.module.css
+++ b/src/pages/examples.module.css
@@ -89,6 +89,6 @@
 	}
 	.main > section {
 		display: grid;
-		grid-template-columns: 1fr 2fr;
+		grid-template-columns: minmax(20rem, 1fr) 2fr;
 	}
 }

--- a/src/pages/examples.module.css
+++ b/src/pages/examples.module.css
@@ -63,7 +63,6 @@
 	max-width: 30rem;
 	border-radius: 5px;
 	padding: 1rem;
-	font-size: 0.8rem;
 }
 
 .options-wrapper > div {

--- a/src/pages/examples.tsx
+++ b/src/pages/examples.tsx
@@ -58,7 +58,7 @@ type State = {
 };
 
 const initialState: State = {
-	height: 500,
+	height: 570,
 	restrictions: null,
 	disabled: false,
 	theme: 'light',

--- a/src/pages/examples.tsx
+++ b/src/pages/examples.tsx
@@ -1,10 +1,4 @@
-import React, {
-	memo,
-	useCallback,
-	useEffect,
-	useReducer,
-	useState,
-} from 'react';
+import React, { useCallback, useEffect, useReducer, useState } from 'react';
 
 import Layout from '@theme/Layout';
 import Admonition from '@theme/Admonition';
@@ -48,8 +42,8 @@ const restrictions = {
 
 type Action = { type: string; checked?: boolean; value: string };
 type State = {
-	width?: number;
-	height: number;
+	width?: number | string;
+	height: number | string;
 	restrictions?: typeof restrictions;
 	disabled: boolean;
 	theme: 'light' | 'dark' | 'auto';
@@ -59,6 +53,7 @@ type State = {
 
 const initialState: State = {
 	height: 570,
+	width: '100%',
 	restrictions: null,
 	disabled: false,
 	theme: 'light',

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -434,7 +434,6 @@
 .footer {
 	background-color: #15192a;
 	color: #fff;
-	font-size: 12px;
 	margin-top: 50px;
 	padding: 2em 1em 3em;
 	text-align: center;

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -397,9 +397,6 @@
 		gap: 0 1rem;
 		align-items: start;
 	}
-	.section-much-more li {
-		margin: 0;
-	}
 }
 
 .section-much-more ul + div {

--- a/src/theme/BlogPostItem/Footer/index.js
+++ b/src/theme/BlogPostItem/Footer/index.js
@@ -5,6 +5,7 @@ import EditThisPage from '@theme/EditThisPage';
 import TagsListInline from '@theme/TagsListInline';
 import ReadMoreLink from '@theme/BlogPostItem/Footer/ReadMoreLink';
 import styles from './styles.module.css';
+
 export default function BlogPostItemFooter() {
 	const { metadata, isBlogPostPage } = useBlogPost();
 	const { tags, title, editUrl, hasTruncateMarker } = metadata;
@@ -28,34 +29,37 @@ export default function BlogPostItemFooter() {
 				</div>
 			)}
 
-			{isBlogPostPage && editUrl && (
-				<div className="col margin-top--sm">
-					<ul className="blog__post-footer__follow">
-						<li>
-							<a href="https://twitter.com/uppy_io">Follow us on Twitter</a> or
-							grab the <a href="https://uppy.io/blog/atom.xml">RSS feed</a>
-						</li>
-						<li>
-							<a
-								className="github-button"
-								href="https://github.com/transloadit/uppy"
-								data-icon="octicon-star"
-								data-size="large"
-								data-show-count="true"
-								aria-label="Star transloadit/uppy on GitHub"
-							>
-								Star
-							</a>
-						</li>
-					</ul>
-				</div>
+			{isBlogPostPage && (
+				<ul className={styles.footer}>
+					<li>
+						<a
+							target="_blank"
+							rel="noopener"
+							href="https://twitter.com/uppy_io"
+						>
+							Twitter
+						</a>
+					</li>
+					<li>
+						<a
+							target="_blank"
+							rel="noopener"
+							href="https://uppy.io/blog/atom.xml"
+						>
+							RSS feed
+						</a>
+					</li>
+					<li>
+						<a
+							target="_blank"
+							rel="noopener"
+							href="https://github.com/transloadit/uppy"
+						>
+							GitHub
+						</a>
+					</li>
+				</ul>
 			)}
-
-			{/* {isBlogPostPage && editUrl && (
-				<div className="col margin-top--sm">
-					<EditThisPage editUrl={editUrl} />
-				</div>
-			)} */}
 
 			{truncatedPost && (
 				<div

--- a/src/theme/BlogPostItem/Footer/styles.module.css
+++ b/src/theme/BlogPostItem/Footer/styles.module.css
@@ -1,3 +1,16 @@
+.footer {
+	margin: 0 1rem;
+	border-radius: var(--ifm-pagination-nav-border-radius);
+	list-style: none;
+	border-color: lightgray;
+	border-style: solid;
+	border-width: 1px;
+	padding: 1rem;
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	text-align: center;
+}
+
 .blogPostFooterDetailsFull {
 	flex-direction: column;
 }


### PR DESCRIPTION
Make the typography consistent again. I naively made this website only for desktop sizes which are around my laptop size, but in screenshares I've seen that on @arturi's laptop the typography is too big. Artur later implemented some fixes to make things a bit smaller here and there, but this became a bit inconsistent in my opinion. Instead, everything is now base font size but between 1000 and 1300px laptop screens the base font size is decreased, making it overall more fitting.

I also updated the blog post footer links:

 
<img width="1716" alt="Screenshot 2023-05-17 at 12 27 42" src="https://github.com/transloadit/uppy.io/assets/9060226/bc0cf171-0d0e-4824-ab85-e92fc8fe9f25">
