### PR TITLE
Update react.mdx add id

### DIFF
--- a/docs/framework-integrations/react.mdx
+++ b/docs/framework-integrations/react.mdx
@@ -80,7 +80,7 @@ import '@uppy/dashboard/dist/style.min.css';
 import '@uppy/webcam/dist/style.min.css';
 
 // Don’t forget to keep the Uppy instance outside of your component.
-const uppy = new Uppy().use(Webcam);
+const uppy = new Uppy().use(Webcam, {id: 'upload' });
 
 function Component() {
 	return <Dashboard uppy={uppy} plugins={['Webcam']} />;


### PR DESCRIPTION
Otherwise upload won't work when using nextjs. Error will appear:

TypeError: plugin.mount is not a function
TypeError: Cannot read properties of undefined (reading 'id')
Error: Already found a plugin named 'react:Dashboard'. Tried to use: 'react:Dashboard'.
Uppy plugins must have unique `id` options. See https://uppy.io/docs/plugins/#id.