### PR TITLE
Replace broken link to aws-presigned-url example

### DIFF
--- a/docs/uploader/aws-s3.mdx
+++ b/docs/uploader/aws-s3.mdx
@@ -434,7 +434,7 @@ uppy.use(AwsS3, {
 ```
 
 See the
-[aws-presigned-url example in the uppy repository](https://github.com/transloadit/uppy/tree/main/examples/aws-presigned-url)
+[aws-php example in the uppy repository](https://github.com/transloadit/uppy/tree/main/examples/aws-php)
 for a small example that implements both the server-side and the client-side.
 
 ### How can I retrieve the presigned parameters of the uploaded file?

--- a/docs/uploader/aws-s3.mdx
+++ b/docs/uploader/aws-s3.mdx
@@ -433,9 +433,11 @@ uppy.use(AwsS3, {
 });
 ```
 
-See the
-[aws-php example in the uppy repository](https://github.com/transloadit/uppy/tree/main/examples/aws-php)
-for a small example that implements both the server-side and the client-side.
+See either the
+[aws-nodejs](https://github.com/transloadit/uppy/tree/HEAD/examples/aws-nodejs)
+or [aws-php](https://github.com/transloadit/uppy/tree/HEAD/examples/aws-php)
+examples in the uppy repository for a demonstration of how to implement
+handling of presigned URLs on both the server-side and client-side.
 
 ### How can I retrieve the presigned parameters of the uploaded file?
 

--- a/docs/uploader/aws-s3.mdx
+++ b/docs/uploader/aws-s3.mdx
@@ -436,8 +436,8 @@ uppy.use(AwsS3, {
 See either the
 [aws-nodejs](https://github.com/transloadit/uppy/tree/HEAD/examples/aws-nodejs)
 or [aws-php](https://github.com/transloadit/uppy/tree/HEAD/examples/aws-php)
-examples in the uppy repository for a demonstration of how to implement
-handling of presigned URLs on both the server-side and client-side.
+examples in the uppy repository for a demonstration of how to implement handling
+of presigned URLs on both the server-side and client-side.
 
 ### How can I retrieve the presigned parameters of the uploaded file?
 


### PR DESCRIPTION
In the AWS S3 uploader documentation, there is a broken link which references an `aws-presigned-url` example which does not exist.

I have replaced this link with one to the `aws-php` example, which also implements the server-side and client-side usage of AWS S3 presigned URLs as the `aws-presigned-url` example was claimed to do.