### PR TITLE
Remove (configurable) in Golden Retriever docs

### DIFF
--- a/docs/golden-retriever.mdx
+++ b/docs/golden-retriever.mdx
@@ -83,8 +83,8 @@ new Uppy()
 ```
 
 By default, Golden Retriever will only use the `IndexedDB` storage, which is
-good enough for files up to 5 MiB. `Service Worker` is optional
-and requires setup.
+good enough for files up to 5 MiB. `Service Worker` is optional and requires
+setup.
 
 ### Enabling Service Worker
 

--- a/docs/golden-retriever.mdx
+++ b/docs/golden-retriever.mdx
@@ -83,7 +83,7 @@ new Uppy()
 ```
 
 By default, Golden Retriever will only use the `IndexedDB` storage, which is
-good enough for files up to 5 MiB (configurable). `Service Worker` is optional
+good enough for files up to 5 MiB. `Service Worker` is optional
 and requires setup.
 
 ### Enabling Service Worker


### PR DESCRIPTION
According to https://github.com/transloadit/uppy/issues/4518#issuecomment-1602211752 this value is not configurable. 

This PR corrects the docs to remove the suggestion that the value is configurable.