### PR TITLE
@uppy/aws-s3-multipart: document `getUploadParameters`

### DIFF
--- a/docs/uploader/aws-s3-multipart.mdx
+++ b/docs/uploader/aws-s3-multipart.mdx
@@ -36,8 +36,8 @@ completion requests besides the upload requests. For example, if you are
 uploading files that are only a couple kilobytes with a 100ms roundtrip latency,
 you are spending 400ms on overhead and only a few milliseconds on uploading.
 
-If you are uploading large files (100&nbsp;MB+), we recommend
-`@uppy/aws-s3-multipart`, otherwise [`@uppy/aws-s3`][].
+We recomend setting [`shouldUseMultipart`][] option to use the right upload
+method depending on the file size.
 
 ## Install
 
@@ -441,5 +441,5 @@ A function that will be called for each non-multipart upload.
     the browser may decide on a different content-type instead, causing S3 to
     reject the upload.
 
-[`@uppy/aws-s3`]: /docs/aws-s3
+[`shouldusemultipart`]: #shouldusemultipartfile
 [companion docs]: /docs/companion

--- a/docs/uploader/aws-s3-multipart.mdx
+++ b/docs/uploader/aws-s3-multipart.mdx
@@ -410,8 +410,36 @@ uppy.use(AwsS3Multipart, {
 });
 ```
 
-#### `getUploadParameters(file)`
+#### `getUploadParameters(file, options)`
 
-See [`@uppy/aws-s3`][]. This option is used only for non-multipart uploads.
+:::note
+
+When using [Companion][companion docs] to sign S3 uploads, you should not define
+this option.
+
+:::
+
+A function that will be called for each non-multipart upload.
+
+- `file`: `UppyFile` the file that will be uploaded
+- `options`: `object`
+  - `signal`: `AbortSignal`
+- **Returns:** `object | Promise<object>`
+  - `method`: `string`, the HTTP method to be used for the upload. This should
+    be one of either `PUT` or `POST`, depending on the type of upload used.
+  - `url`: `string`, the URL to which the upload request will be sent. When
+    using a presigned PUT upload, this should be the URL to the S3 object with
+    signing parameters included in the query string. When using a POST upload
+    with a policy document, this should be the root URL of the bucket.
+  - `fields` `object`, an object with form fields to send along with the upload
+    request. For presigned PUT uploads (which are default), this should be left
+    empty.
+  - `headers`: `object`, an object with request headers to send along with the
+    upload request. When using a presigned PUT upload, it’s a good idea to
+    provide `headers['content-type']`. That will make sure that the request uses
+    the same content-type that was used to generate the signature. Without it,
+    the browser may decide on a different content-type instead, causing S3 to
+    reject the upload.
 
 [`@uppy/aws-s3`]: /docs/aws-s3
+[companion docs]: /docs/companion

--- a/docs/uploader/aws-s3-multipart.mdx
+++ b/docs/uploader/aws-s3-multipart.mdx
@@ -36,8 +36,9 @@ completion requests besides the upload requests. For example, if you are
 uploading files that are only a couple kilobytes with a 100ms roundtrip latency,
 you are spending 400ms on overhead and only a few milliseconds on uploading.
 
-We recomend setting [`shouldUseMultipart`][] option to use the right upload
-method depending on the file size.
+Since `3.2.0` of the `aws-s3` package and `3.3.0` of this package, we recommend
+you use [`shouldUseMultipart`][]. This package will eventually be merged into
+`aws-s3` so it is better to use the option with that package already.
 
 ## Install
 


### PR DESCRIPTION
Referencing `@uppy/aws-s3` docs won't work once we merged the two plugins, so we might as well do a bit of repetition, but that should also improve the readability of the page.