### PR TITLE
Remove reset() method from uppy-core.mdx

### DIFF
--- a/docs/uppy-core.mdx
+++ b/docs/uppy-core.mdx
@@ -826,15 +826,10 @@ uppy.getPlugin('Dashboard').setOptions({
 });
 ```
 
-#### `reset()`
-
-Stop all uploads in progress and clear file selection, set progress to 0. More
-or less, it returns things to the way they were before any user input.
-
 #### `close()`
 
 Uninstall all plugins and close down this Uppy instance. Also runs
-`uppy.reset()` before uninstalling.
+`uppy.cancelAll()` before uninstalling.
 
 #### `logout()`
 


### PR DESCRIPTION
---
The `reset()` method has been removed from v3, apparently: https://uppy.io/docs/guides/migration-guides/#remove-reset-method

Coming into using Uppy as a new user, I found the 'reset' function in the docs and spent way too long to figure out what and why it wasn't working 😅  Then I found the replacement (`cancelAll()`) in the migration docs.

This PR is to simply update the docs to no longer reference the `reset()` method.

Let me know if this is okay or if you prefer to keep it for now or perhaps add a message in the docs stating it's not in v3 anymore.

---