### PR TITLE
fix UppyCdnExample

### DIFF
--- a/src/components/UppyCdnExample.tsx
+++ b/src/components/UppyCdnExample.tsx
@@ -10,7 +10,7 @@ const { version: uppyVersion } = packageJson;
 export default function UppyCdnExample({
 	children,
 	uppyCssName = 'uppy.min.css',
-	uppyJsName = 'uppy.min.js',
+	uppyJsName = 'uppy.min.mjs',
 }) {
 	let lines = [];
 


### PR DESCRIPTION
The CDN exposes the legacy bundle under the `.js` extension, we want folks to use the `.mjs` one which contains ESM code.