### PR TITLE
More compact Table of Contents

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -156,6 +156,9 @@ const config = {
 				theme: lightCodeTheme,
 				darkTheme: darkCodeTheme,
 			},
+			tableOfContents: {
+				maxHeadingLevel: 2,
+			}
 		}),
 };
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -117,7 +117,7 @@ p > code {
 	font-size: var(--ifm-font-size-base);
 }
 
-/* 
+/*
 * Admonitions have long generated class names.
 * We want to change the heading font, but it's not an config option.
 */
@@ -154,14 +154,10 @@ div[class*=' admonitionHeading'] {
 	font-weight: 500;
 }
 
-h1[itemprop='headline'] {
-	font-size: 2.4rem;
-	margin-bottom: 0.6rem;
-}
-
+h1[itemprop='headline'],
 h2[itemprop='headline'] {
-	font-size: 2.4rem;
-	margin-bottom: 0.6rem;
+	font-size: 2rem;
+	margin-bottom: 0.4rem;
 }
 
 /* Content Body */


### PR DESCRIPTION
I noticed that the Table of Contents is overly detailed in the recent blog post. It even causes an extra scrollbar:

<img width="1464" alt="Screenshot 2023-08-10 at 13 34 34@2x" src="https://github.com/transloadit/uppy.io/assets/375537/a7668209-eb78-4d9a-ad3c-f32c94fda473">

I propose that we only show the `<h2>` tags here, as I don't think there's a need to provide such a complete structure. Here's how the more compact version looks: 

<img width="1464" alt="Screenshot 2023-08-10 at 13 38 52@2x" src="https://github.com/transloadit/uppy.io/assets/375537/fcdfa3b3-7fa4-4c13-b941-4497908a2514">

* * *

**Note:** This change also affects Docs. Also LGTM there: 

![Screenshot 2023-08-10 at 13 40 55](https://github.com/transloadit/uppy.io/assets/375537/9ccbaed9-239f-447d-90ab-67ec6f2fcb91)

**Note 2**: I also slightly reduced the post headings font size. You can notice the difference on the first two screenshots.
