### PR TITLE
Correct docs for Dashboard default doneButtonHandler

### DIFF
--- a/docs/user-interfaces/dashboard.mdx
+++ b/docs/user-interfaces/dashboard.mdx
@@ -212,7 +212,7 @@ Use this if you are providing a custom retry button somewhere, and using the
 
 Hide the status bar after the upload has finished (`boolean`, default: `false`).
 
-#### `doneButtonHandler()`
+#### `doneButtonHandler`
 
 This option is passed to the status bar and will render a “Done” button in place
 of pause/resume/cancel buttons, once the upload/encoding is done. The behaviour
@@ -223,7 +223,7 @@ This is what the Dashboard sets by default:
 
 ```js
 const doneButtonHandler = () => {
-	this.uppy.reset();
+	this.uppy.cancelAll();
 	this.requestCloseModal();
 };
 ```


### PR DESCRIPTION
Quick fix to the Dashboard docs to update the default doneButtonHandler to match the actual code.

Currently, the docs reference uppy.reset() which doesn't appear to exist.


https://github.com/transloadit/uppy/blob/3205cc3500856db7f8f3369eecc5222f914290dd/packages/%40uppy/dashboard/src/Dashboard.jsx#L69

```
      doneButtonHandler: () => {
        this.uppy.cancelAll()
        this.requestCloseModal()
      },
```