### PR TITLE
Dynamic oauth credentials testing

### DIFF
--- a/src/pages/examples.tsx
+++ b/src/pages/examples.tsx
@@ -193,7 +193,7 @@ const Uppy = ({ state, locale }) => {
 			.use(Audio)
 			.use(ImageEditor, {})
 			.use(Tus, { endpoint })
-			.use(GoogleDrive, { companionUrl })
+			.use(GoogleDrive, { companionUrl, companionKeysParams: { key: 'unused-key', credentialsName: 'unused-credentials' } })
 			.use(Dropbox, { companionUrl })
 			.use(Instagram, { companionUrl })
 			.use(Url, { companionUrl })

--- a/src/pages/examples.tsx
+++ b/src/pages/examples.tsx
@@ -193,7 +193,13 @@ const Uppy = ({ state, locale }) => {
 			.use(Audio)
 			.use(ImageEditor, {})
 			.use(Tus, { endpoint })
-			.use(GoogleDrive, { companionUrl, companionKeysParams: { key: 'unused-key', credentialsName: 'unused-credentials' } })
+			.use(GoogleDrive, {
+				companionUrl,
+				companionKeysParams: {
+					key: 'unused-key',
+					credentialsName: 'unused-credentials',
+				},
+			})
 			.use(Dropbox, { companionUrl })
 			.use(Instagram, { companionUrl })
 			.use(Url, { companionUrl })

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -231,7 +231,7 @@ export default function Home(): JSX.Element {
 										.use(Audio)
 										.use(ImageEditor, {})
 										.use(Tus, { endpoint })
-										.use(GoogleDrive, { companionUrl })
+										.use(GoogleDrive, { companionUrl, companionKeysParams: { key: 'unused-key', credentialsName: 'unused-credentials' } })
 										.use(Dropbox, { companionUrl })
 										.use(Instagram, { companionUrl })
 										.use(Url, { companionUrl })

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -231,7 +231,13 @@ export default function Home(): JSX.Element {
 										.use(Audio)
 										.use(ImageEditor, {})
 										.use(Tus, { endpoint })
-										.use(GoogleDrive, { companionUrl, companionKeysParams: { key: 'unused-key', credentialsName: 'unused-credentials' } })
+										.use(GoogleDrive, {
+											companionUrl,
+											companionKeysParams: {
+												key: 'unused-key',
+												credentialsName: 'unused-credentials',
+											},
+										})
 										.use(Dropbox, { companionUrl })
 										.use(Instagram, { companionUrl })
 										.use(Url, { companionUrl })


### PR DESCRIPTION
enable dynamic oauth credentials fetching for google drive. this allows us to more easily spot if this implementation breaks.

note: depends on https://github.com/transloadit/uppy/pull/4667

## TODO after these PRs are merged

in heroku: (replace `ADDSOMESECRETVALUEHERE` with a real random secret)

- [x] `COMPANION_GOOGLE_KEYS_ENDPOINT=https://companion.uppy.io/drive/test-dynamic-oauth-credentials?secret=ADDSOMESECRETVALUEHERE` (or maybe use `localhost` to avoid proxy roundtrip?)
- [x] `COMPANION_TEST_DYNAMIC_OAUTH_CREDENTIALS=true`
- [x] `COMPANION_TEST_DYNAMIC_OAUTH_CREDENTIALS_SECRET=ADDSOMESECRETVALUEHERE`
