### PR TITLE
fix navbar going behind uppy

### DIFF
--- a/src/pages/examples.module.css
+++ b/src/pages/examples.module.css
@@ -92,3 +92,8 @@
 		grid-template-columns: minmax(20rem, 1fr) 2fr;
 	}
 }
+
+.dashboard-inner {
+	position: relative;
+	z-index: 1;
+}

--- a/src/pages/examples.tsx
+++ b/src/pages/examples.tsx
@@ -326,9 +326,11 @@ export default function Examples() {
 							})}
 						</select>
 					</div>
-					<BrowserOnly>
-						{() => <Uppy state={state} locale={locale} />}
-					</BrowserOnly>
+					<div className={styles['dashboard-inner']}>
+						<BrowserOnly>
+							{() => <Uppy state={state} locale={locale} />}
+						</BrowserOnly>
+					</div>
 				</section>
 				<Admonition type="note">
 					Checkout our{' '}


### PR DESCRIPTION
on the examples page. note: this is a workaround and we might want to instead fix it by not using z-indexes inside uppy, but that's probably a bigger task