### PR TITLE
Make example page options persistent

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 		"@docusaurus/plugin-client-redirects": "^3.0.0",
 		"@docusaurus/preset-classic": "^3.0.0",
 		"@mdx-js/react": "^3.0.0",
+		"@uidotdev/usehooks": "^2.4.1",
 		"@uppy/audio": "latest",
 		"@uppy/box": "latest",
 		"@uppy/core": "latest",

--- a/src/pages/examples.module.css
+++ b/src/pages/examples.module.css
@@ -30,8 +30,13 @@
 	color: gray;
 }
 
-.main input[type='checkbox']:not(:checked):hover + label {
+.main input[type='checkbox']:not(:checked, :disabled):hover + label {
 	color: black;
+}
+
+.main input[type='checkbox']:disabled:hover,
+.main input[type='checkbox']:disabled:hover + label {
+	cursor: not-allowed;
 }
 
 .main select {

--- a/src/pages/examples.tsx
+++ b/src/pages/examples.tsx
@@ -258,6 +258,11 @@ const companionUrl = 'https://companion.uppy.io';
 const endpoint = 'https://tusd.tusdemo.net/files/';
 
 export default function Examples() {
+	// Silly trick to please Docusaurus with client-side hooks such as useLocalStorage
+	return <BrowserOnly>{() => <Page />}</BrowserOnly>;
+}
+
+function Page() {
 	const [state, setPersistentState] = useLocalStorage(
 		'uppy-examples-state',
 		initialState,

--- a/src/pages/examples.tsx
+++ b/src/pages/examples.tsx
@@ -113,12 +113,16 @@ const options = [
 				label: 'Instagram',
 				value: 'Instagram',
 				type: 'plugins',
+				title:
+					'Temporarily disabled until our credentials are approved again. You can still use the plugin yourself.',
 				disabled: true,
 			},
 			{
 				label: 'Facebook',
 				value: 'Facebook',
 				type: 'plugins',
+				title:
+					'Temporarily disabled until our credentials are approved again. You can still use the plugin yourself.',
 				disabled: true,
 			},
 			{ label: 'Url', value: 'Url', type: 'plugins' },
@@ -306,34 +310,39 @@ function Page() {
 										wrapper-for={section.heading}
 										className={styles['options-wrapper']}
 									>
-										{section.options.map(({ label, value, type, disabled }) => (
-											<div key={label}>
-												<input
-													type="checkbox"
-													id={label}
-													className={styles['framework-input']}
-													name="framework"
-													value={type}
-													checked={
-														// Forgive me for this logic
-														Array.isArray(state[type])
-															? state[type].includes(value)
-															: type === 'theme'
-															? state.theme === 'dark'
-															: state[type]
-													}
-													disabled={disabled}
-													onChange={(event) =>
-														dispatch({
-															type: type,
-															checked: event.target.checked,
-															value,
-														})
-													}
-												/>
-												<label htmlFor={label}>{label}</label>
-											</div>
-										))}
+										{section.options.map(
+											({ label, value, type, disabled, title }) => (
+												<div key={label}>
+													<input
+														type="checkbox"
+														id={label}
+														className={styles['framework-input']}
+														name="framework"
+														value={type}
+														title={title}
+														checked={
+															// Forgive me for this logic
+															Array.isArray(state[type])
+																? state[type].includes(value)
+																: type === 'theme'
+																? state.theme === 'dark'
+																: state[type]
+														}
+														disabled={disabled}
+														onChange={(event) =>
+															dispatch({
+																type: type,
+																checked: event.target.checked,
+																value,
+															})
+														}
+													/>
+													<label title={title} htmlFor={label}>
+														{label}
+													</label>
+												</div>
+											),
+										)}
 									</div>
 								</div>
 							);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
 	"extends": "@docusaurus/tsconfig",
 	"compilerOptions": {
 		"baseUrl": ".",
-		"resolveJsonModule": true
+		"resolveJsonModule": true,
+		"jsx": "react"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4758,6 +4758,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@uidotdev/usehooks@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "@uidotdev/usehooks@npm:2.4.1"
+  peerDependencies:
+    react: ">=18.0.0"
+    react-dom: ">=18.0.0"
+  checksum: 7f2e1dcfcaf654841150fde36556a257afb2240bca0145586b4e1e9385b85fea108a7dd17c2cbc4c2bd46d136126ffdf84267118933120fe54ad2e028c2dfa68
+  languageName: node
+  linkType: hard
+
 "@ungap/structured-clone@npm:^1.0.0":
   version: 1.2.0
   resolution: "@ungap/structured-clone@npm:1.2.0"
@@ -17685,6 +17695,7 @@ __metadata:
     "@tsconfig/docusaurus": "npm:^2.0.2"
     "@typescript-eslint/eslint-plugin": "npm:^5.48.1"
     "@typescript-eslint/parser": "npm:^5.48.1"
+    "@uidotdev/usehooks": "npm:^2.4.1"
     "@uppy/audio": "npm:latest"
     "@uppy/box": "npm:latest"
     "@uppy/core": "npm:latest"


### PR DESCRIPTION
Closes #110 
Closes #119

Also fixes:
- Order of plugins are constantly changing when you check/uncheck them
- Screen Capture not working
- Golden Retriever never worked before since it would be off by default and it only shows what it does after a refresh. Persistent options fixes this too.
- Make Instagram / Facebook disabled with disabled styles for now (https://github.com/transloadit/uppy/issues/4905)

code is not pretty but it works and it's just a small page 🤷‍♂️ 