### PR TITLE
meta: add custom plugin to handle symlinks

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -82,6 +82,7 @@ const config = {
 				],
 			},
 		],
+		'./src/plugins/custom.js',
 	],
 	scripts: [
 		{

--- a/src/plugins/custom.js
+++ b/src/plugins/custom.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = function (context, options) {
+	return {
+		name: 'custom-docusaurus-plugin',
+		configureWebpack(config, isServer, utils) {
+			return {
+				resolve: {
+					symlinks: false,
+				},
+			};
+		},
+	};
+};


### PR DESCRIPTION
Webpack has a special option for handling symbolink links. Necessary to unblock https://github.com/transloadit/uppy.io/pull/217.