### PR TITLE
docs(sources/companion-plugins/google-drive): adds information on required app scopes.

### DIFF
--- a/docs/sources/companion-plugins/google-drive.mdx
+++ b/docs/sources/companion-plugins/google-drive.mdx
@@ -96,7 +96,7 @@ Create a project for your app if you don’t have one yet.
 - [Set up OAuth authorization](https://developers.google.com/drive/api/v3/about-auth).
   - Under scopes, add the `https://www.googleapis.com/auth/drive.readonly` Drive
     API scope.
-  - Due to this being a sensitive scope, your app must complete Google's OAuth
+  - Due to this being a sensitive scope, your app must complete Google’s OAuth
     app verification before being granted access. See
     [OAuth App Verification Help Center](https://support.google.com/cloud/answer/13463073)
     for more information.


### PR DESCRIPTION
Took me a little code diving/GH issue spelunking to find this, so thought it might be nice to add it to the docs for others/my future self 👍

Refer:
- https://github.com/transloadit/uppy/blob/37d0a03390b4e704949dbe5f2bfc9e116e3cba1c/packages/%40uppy/companion/src/config/grant.js#L8
- https://github.com/transloadit/uppy/issues/2288
- https://github.com/transloadit/uppy/issues/4793

![Screenshot 2024-04-11 at 5 06 23 PM](https://github.com/transloadit/uppy.io/assets/6119549/3d959485-98d0-4b6a-84bd-22a1840cfa76)
