### PR TITLE
Revert "Bump remark-mdx from 2.3.0 to 3.0.1 (#233)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
 		"remark-lint-no-undefined-references": "^4.0.0",
 		"remark-lint-no-unused-definitions": "^4.0.0",
 		"remark-lint-ordered-list-marker-style": "^3.0.0",
-		"remark-mdx": "^3.0.1",
+		"remark-mdx": "^2.1.2",
 		"remark-preset-lint-consistent": "^5.1.1",
 		"remark-preset-lint-markdown-style-guide": "^5.1.2",
 		"remark-preset-prettier": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13873,7 +13873,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"remark-mdx@npm:^2.3.0":
+"remark-mdx@npm:^2.1.2, remark-mdx@npm:^2.3.0":
   version: 2.3.0
   resolution: "remark-mdx@npm:2.3.0"
   dependencies:
@@ -13883,7 +13883,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"remark-mdx@npm:^3.0.0, remark-mdx@npm:^3.0.1":
+"remark-mdx@npm:^3.0.0":
   version: 3.0.1
   resolution: "remark-mdx@npm:3.0.1"
   dependencies:
@@ -16105,7 +16105,7 @@ __metadata:
     remark-lint-no-undefined-references: "npm:^4.0.0"
     remark-lint-no-unused-definitions: "npm:^4.0.0"
     remark-lint-ordered-list-marker-style: "npm:^3.0.0"
-    remark-mdx: "npm:^3.0.1"
+    remark-mdx: "npm:^2.1.2"
     remark-preset-lint-consistent: "npm:^5.1.1"
     remark-preset-lint-markdown-style-guide: "npm:^5.1.2"
     remark-preset-prettier: "npm:^2.0.1"


### PR DESCRIPTION
This reverts commit 6fcf7eea02a09f79e0f2e36680af27389c730f2f.