### PR TITLE
docusaurus.config.js - fix all doc edit links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -27,7 +27,7 @@ const config = {
 				docs: {
 					breadcrumbs: false,
 					sidebarPath: require.resolve('./sidebars.js'),
-					editUrl: 'https://github.com/transloadit/uppy.io/tree/main',
+					editUrl: 'https://github.com/transloadit/uppy/blob/main/',
 				},
 				blog: {
 					showReadingTime: true,


### PR DESCRIPTION
# Before

<img width="400" alt="image" src="https://github.com/transloadit/uppy.io/assets/7578559/3160f210-138b-44d6-b71d-f9d9b5d841c6">

clicking "Edit this page" leads to:

<img width="800" alt="image" src="https://github.com/transloadit/uppy.io/assets/7578559/f7ee3ba9-8b65-471b-9949-b9bc36a5c1d5">


# After

<img width="400" alt="image" src="https://github.com/transloadit/uppy.io/assets/7578559/c7d1e704-1f4c-4609-9775-5dda036a4bc3">

clicking "Edit this page" leads to:

<img width="800" alt="image" src="https://github.com/transloadit/uppy.io/assets/7578559/dc421469-6538-4fa1-9783-1cdfdf79a3fc">
