### PR TITLE
uppy.io/examples - stop css from affecting uppy

### DIFF
--- a/src/pages/examples.module.css
+++ b/src/pages/examples.module.css
@@ -72,6 +72,11 @@
 	z-index: 1;
 }
 
+.dashboard-inner :is(h1, h2, h3, h4, h5, h6) {
+	/* This is a copypaste from Uppy; here we're making sure docusaurus styles don't override Uppy's styles */
+	font-family: -apple-system,system-ui,BlinkMacSystemFont,Segoe UI,Segoe UI Symbol,Segoe UI Emoji,Apple Color Emoji,Roboto,Helvetica,Arial,sans-serif;
+}
+
 @media screen and (min-width: 60rem) {
 	.main {
 		padding: 0;

--- a/src/pages/examples.module.css
+++ b/src/pages/examples.module.css
@@ -3,17 +3,26 @@
 	margin: 4rem auto;
 	padding: 0 1rem;
 }
-
-.main .h1 {
+.h1 {
 	font-size: 3rem;
 }
-
-.main .h3 {
+.h3 {
 	font-size: 1rem;
 	font-family: var(--ifm-font-family-base);
 }
 
-.main .options-and-uppy {
+.dashboard-docs-stackblitz {
+	display: flex;
+	align-items: baseline;
+	gap: 1rem;
+	margin-top: 2rem;
+}
+.dashboard-docs-stackblitz h2,
+.dashboard-docs-stackblitz p {
+	margin-bottom: 0.5rem;
+}
+
+.options-and-uppy {
 	position: relative;
 	border-radius: 5px;
 	margin-bottom: 1rem;
@@ -23,41 +32,6 @@
 		rgba(0, 0, 0, 0.1) 0px 4px 6px -1px,
 		rgba(0, 0, 0, 0.1) 0px 2px 4px -2px;
 }
-
-.main input[type='checkbox'] {
-	accent-color: #f37;
-}
-
-.main input[type='checkbox']:not(:checked, :disabled):hover + label {
-	color: black;
-}
-
-.main input[type='checkbox']:disabled:hover,
-.main input[type='checkbox']:disabled:hover + label {
-	cursor: not-allowed;
-}
-
-.main select {
-	grid-column: 1 / 3;
-	background: white;
-	padding: 0.2rem 1rem;
-	font-size: 1rem;
-	border: 1px solid lightgray;
-	border-radius: 5px;
-}
-
-.header {
-	display: flex;
-	align-items: baseline;
-	gap: 1rem;
-	margin-top: 2rem;
-}
-
-.header h2,
-.header p {
-	margin-bottom: 0.5rem;
-}
-
 .options {
 	display: grid;
 	grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -67,11 +41,33 @@
 	border-radius: 5px;
 	padding: 1rem;
 }
-
-.options-wrapper > div {
+.options input[type='checkbox'] {
+	accent-color: #f37;
+}
+.options-inner > div {
 	display: flexl;
 	align-items: center;
 	margin: 0.25rem 0;
+}
+.options input[type='checkbox']:not(:checked, :disabled):hover + label {
+	color: black;
+}
+.options input[type='checkbox']:disabled:hover,
+.options input[type='checkbox']:disabled:hover + label {
+	cursor: not-allowed;
+}
+.options select {
+	grid-column: 1 / 3;
+	background: white;
+	padding: 0.2rem 1rem;
+	font-size: 1rem;
+	border: 1px solid lightgray;
+	border-radius: 5px;
+}
+
+.dashboard-inner {
+	position: relative;
+	z-index: 1;
 }
 
 @media screen and (min-width: 60rem) {
@@ -86,17 +82,12 @@
 	.options > div:first-of-type {
 		grid-column: 1 / 3;
 	}
-	.options-wrapper[wrapper-for='Remote sources'] {
+	.options-inner[wrapper-for='Remote sources'] {
 		display: grid;
 		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
-	.main > section {
+	.options-and-uppy {
 		display: grid;
 		grid-template-columns: minmax(20rem, 1fr) 2fr;
 	}
-}
-
-.dashboard-inner {
-	position: relative;
-	z-index: 1;
 }

--- a/src/pages/examples.module.css
+++ b/src/pages/examples.module.css
@@ -74,7 +74,18 @@
 
 .dashboard-inner :is(h1, h2, h3, h4, h5, h6) {
 	/* This is a copypaste from Uppy; here we're making sure docusaurus styles don't override Uppy's styles */
-	font-family: -apple-system,system-ui,BlinkMacSystemFont,Segoe UI,Segoe UI Symbol,Segoe UI Emoji,Apple Color Emoji,Roboto,Helvetica,Arial,sans-serif;
+	font-family:
+		-apple-system,
+		system-ui,
+		BlinkMacSystemFont,
+		Segoe UI,
+		Segoe UI Symbol,
+		Segoe UI Emoji,
+		Apple Color Emoji,
+		Roboto,
+		Helvetica,
+		Arial,
+		sans-serif;
 }
 
 @media screen and (min-width: 60rem) {

--- a/src/pages/examples.module.css
+++ b/src/pages/examples.module.css
@@ -72,22 +72,6 @@
 	z-index: 1;
 }
 
-.dashboard-inner :is(h1, h2, h3, h4, h5, h6) {
-	/* This is a copypaste from Uppy; here we're making sure docusaurus styles don't override Uppy's styles */
-	font-family:
-		-apple-system,
-		system-ui,
-		BlinkMacSystemFont,
-		Segoe UI,
-		Segoe UI Symbol,
-		Segoe UI Emoji,
-		Apple Color Emoji,
-		Roboto,
-		Helvetica,
-		Arial,
-		sans-serif;
-}
-
 @media screen and (min-width: 60rem) {
 	.main {
 		padding: 0;

--- a/src/pages/examples.module.css
+++ b/src/pages/examples.module.css
@@ -4,16 +4,16 @@
 	padding: 0 1rem;
 }
 
-.main h1 {
+.main .h1 {
 	font-size: 3rem;
 }
 
-.main h3 {
+.main .h3 {
 	font-size: 1rem;
 	font-family: var(--ifm-font-family-base);
 }
 
-.main section {
+.main .options-and-uppy {
 	position: relative;
 	border-radius: 5px;
 	margin-bottom: 1rem;

--- a/src/pages/examples.module.css
+++ b/src/pages/examples.module.css
@@ -43,6 +43,8 @@
 }
 .options input[type='checkbox'] {
 	accent-color: #f37;
+	margin-right: 5px;
+	margin-left: 0;
 }
 .options-inner > div {
 	display: flexl;

--- a/src/pages/examples.tsx
+++ b/src/pages/examples.tsx
@@ -293,7 +293,7 @@ function Page() {
 			<main className={styles['main']}>
 				<Heading className={styles['h1']} as="h1">Examples</Heading>
 
-				<div className={styles['header']}>
+				<div className={styles['dashboard-docs-stackblitz']}>
 					<Heading as="h2">Dashboard</Heading>
 					<p>
 						<Link to="/docs/dashboard">Docs</Link> •{' '}
@@ -319,7 +319,7 @@ function Page() {
 									<Heading className={styles['h3']} as="h3">{section.heading}</Heading>
 									<div
 										wrapper-for={section.heading}
-										className={styles['options-wrapper']}
+										className={styles['options-inner']}
 									>
 										{section.options.map(
 											({ label, value, type, disabled, title }) => (
@@ -327,8 +327,6 @@ function Page() {
 													<input
 														type="checkbox"
 														id={label}
-														className={styles['framework-input']}
-														name="framework"
 														value={type}
 														title={title}
 														checked={

--- a/src/pages/examples.tsx
+++ b/src/pages/examples.tsx
@@ -290,10 +290,10 @@ function Page() {
 
 	return (
 		<Layout>
-			<main className={styles.main}>
-				<Heading as="h1">Examples</Heading>
+			<main className={styles['main']}>
+				<Heading className={styles['h1']} as="h1">Examples</Heading>
 
-				<div className={styles.header}>
+				<div className={styles['header']}>
 					<Heading as="h2">Dashboard</Heading>
 					<p>
 						<Link to="/docs/dashboard">Docs</Link> •{' '}
@@ -311,12 +311,12 @@ function Page() {
 					previews and upload progress, lets you edit metadata, and unites
 					acquire plugins, such as Google Drive and Webcam, under one roof.
 				</p>
-				<section>
-					<div className={styles.options}>
+				<section className={styles['options-and-uppy']}>
+					<div className={styles['options']}>
 						{options.map((section) => {
 							return (
 								<div key={section.heading}>
-									<Heading as="h3">{section.heading}</Heading>
+									<Heading className={styles['h3']} as="h3">{section.heading}</Heading>
 									<div
 										wrapper-for={section.heading}
 										className={styles['options-wrapper']}

--- a/src/pages/examples.tsx
+++ b/src/pages/examples.tsx
@@ -291,7 +291,9 @@ function Page() {
 	return (
 		<Layout>
 			<main className={styles['main']}>
-				<Heading className={styles['h1']} as="h1">Examples</Heading>
+				<Heading className={styles['h1']} as="h1">
+					Examples
+				</Heading>
 
 				<div className={styles['dashboard-docs-stackblitz']}>
 					<Heading as="h2">Dashboard</Heading>
@@ -316,7 +318,9 @@ function Page() {
 						{options.map((section) => {
 							return (
 								<div key={section.heading}>
-									<Heading className={styles['h3']} as="h3">{section.heading}</Heading>
+									<Heading className={styles['h3']} as="h3">
+										{section.heading}
+									</Heading>
 									<div
 										wrapper-for={section.heading}
 										className={styles['options-inner']}


### PR DESCRIPTION
Fixes https://github.com/transloadit/uppy/issues/4439

## Makes headings normal-sized & fixes heading font issues

### Before

<img width="400" alt="image" src="https://github.com/user-attachments/assets/b2105ce0-c6e0-4f17-8802-ae539a3188e2">

### After

<img width="400" alt="image" src="https://github.com/user-attachments/assets/0fba68c7-5048-438a-9d0b-31418516f9aa">

## Removes double shadow

### Before

<img width="748" alt="image" src="https://github.com/user-attachments/assets/9b54d69b-fa81-4130-bcab-f34b76fd363a">

### After

<img width="751" alt="image" src="https://github.com/user-attachments/assets/bb30b0ce-d445-4f76-8e6f-5711912d5282">

## Increases right-margin for checkboxes

### Before

<img width="300" alt="image" src="https://github.com/user-attachments/assets/dbb7b6a9-b5a4-49ef-8aaf-50d9997e6600">

### After

<img width="300" alt="image" src="https://github.com/user-attachments/assets/507ea619-3ec7-44f2-a200-34accfb951d7">

___

In general, in CSS, changes:
all tag references (e.g. `h1`),
to unique class references (e.g. `.h1_src-pages-examples-module`).

Hopefully that makes the "Uppy CSS is broken on examples page" issue appear less frequently.