### PR TITLE
use same transloadit oauth2 app

### DIFF
--- a/src/pages/examples.tsx
+++ b/src/pages/examples.tsx
@@ -323,9 +323,9 @@ const companionUrl = 'https://companion.uppy.io';
 // const companionUrl = 'http://localhost:3020';
 const endpoint = 'https://tusd.tusdemo.net/files/';
 const googlePickerClientId =
-	'1020900325465-7naospne1v7veupmu8rg3a6ipfogr9f0.apps.googleusercontent.com';
-const googlePickerApiKey = 'AIzaSyCItfp_WaGGgbNFoU08LMs21ks-MxIqudo';
-const googlePickerAppId = '1020900325465';
+	'458443975467-fiplebcb8bdnplqo8hlfs9pagmseo5nk.apps.googleusercontent.com';
+const googlePickerApiKey = 'AIzaSyC6m6CZEFiTtSkBfNf_-PvtCxmDMiAgfag';
+const googlePickerAppId = '458443975467';
 
 export default function Examples() {
 	// Silly trick to please Docusaurus with client-side hooks such as useLocalStorage

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -47,9 +47,9 @@ import styles from './index.module.css';
 const companionUrl = 'https://companion.uppy.io';
 const endpoint = 'https://tusd.tusdemo.net/files/';
 const googlePickerClientId =
-	'1020900325465-7naospne1v7veupmu8rg3a6ipfogr9f0.apps.googleusercontent.com';
-const googlePickerApiKey = 'AIzaSyCItfp_WaGGgbNFoU08LMs21ks-MxIqudo';
-const googlePickerAppId = '1020900325465';
+	'458443975467-fiplebcb8bdnplqo8hlfs9pagmseo5nk.apps.googleusercontent.com';
+const googlePickerApiKey = 'AIzaSyC6m6CZEFiTtSkBfNf_-PvtCxmDMiAgfag';
+const googlePickerAppId = '458443975467';
 
 const dashboardCode = `import Uppy  from '@uppy/core'
 import Dashboard from '@uppy/dashboard'


### PR DESCRIPTION
because it has been validated. this allows google photos to no longer give "app is blocked" on uppy.io