### PR TITLE
Examples page — design tweaks

### DIFF
--- a/src/pages/examples.module.css
+++ b/src/pages/examples.module.css
@@ -43,13 +43,14 @@
 }
 .options input[type='checkbox'] {
 	accent-color: #f37;
-	margin-right: 5px;
+	margin-right: 0.33rem;
 	margin-left: 0;
 }
 .options-inner > div {
-	display: flexl;
-	align-items: center;
-	margin: 0.25rem 0;
+	display: flex;
+	align-items: baseline;
+	margin: 0 0 0.5rem;
+	line-height: 1.3333;
 }
 .options input[type='checkbox']:disabled + label {
 	color: gray;

--- a/src/pages/examples.module.css
+++ b/src/pages/examples.module.css
@@ -3,11 +3,14 @@
 	margin: 4rem auto;
 	padding: 0 1rem;
 }
+
 .h1 {
 	font-size: 3rem;
 }
+
 .h3 {
-	font-size: 1rem;
+	margin-bottom: 0.5rem;
+	font-size: 0.875rem;
 	font-family: var(--ifm-font-family-base);
 }
 
@@ -17,6 +20,7 @@
 	gap: 1rem;
 	margin-top: 2rem;
 }
+
 .dashboard-docs-stackblitz h2,
 .dashboard-docs-stackblitz p {
 	margin-bottom: 0.5rem;
@@ -25,13 +29,14 @@
 .options-and-uppy {
 	position: relative;
 	border-radius: 5px;
-	margin-bottom: 1rem;
+	margin-bottom: 2rem;
 	box-shadow:
 		rgb(255, 255, 255) 0px 0px 0px 0px,
 		rgba(17, 24, 39, 0.05) 0px 0px 0px 1px,
 		rgba(0, 0, 0, 0.1) 0px 4px 6px -1px,
 		rgba(0, 0, 0, 0.1) 0px 2px 4px -2px;
 }
+
 .options {
 	display: grid;
 	grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -39,36 +44,47 @@
 	min-height: 500px;
 	max-width: 30rem;
 	border-radius: 5px;
-	padding: 1rem;
+	padding: 0.85rem 1rem;
+	font-size: 0.875rem;
 }
+
 .options input[type='checkbox'] {
 	accent-color: #f37;
 	margin-right: 0.33rem;
 	margin-left: 0;
 }
+
 .options-inner > div {
 	display: flex;
 	align-items: baseline;
 	margin: 0 0 0.5rem;
 	line-height: 1.3333;
 }
+
 .options input[type='checkbox']:disabled + label {
 	color: gray;
 }
+
 .options input[type='checkbox']:not(:checked, :disabled):hover + label {
 	color: black;
 }
+
 .options input[type='checkbox']:disabled:hover,
 .options input[type='checkbox']:disabled:hover + label {
 	cursor: not-allowed;
 }
-.options select {
+
+.options-locale {
 	grid-column: 1 / 3;
+}
+
+.options select {
 	background: white;
-	padding: 0.2rem 1rem;
-	font-size: 1rem;
+	padding: 0.2rem 0.25rem;
+	font-size: 0.875rem;
 	border: 1px solid lightgray;
 	border-radius: 5px;
+	width: 100%;
 }
 
 .dashboard-inner {
@@ -80,18 +96,23 @@
 	.main {
 		padding: 0;
 	}
+
 	.options {
 		grid-template-columns: repeat(2, minmax(0, 1fr));
 		gap: 0.5rem;
 		align-items: center;
 	}
+
 	.options > div:first-of-type {
 		grid-column: 1 / 3;
 	}
+
 	.options-inner[wrapper-for='Remote sources'] {
 		display: grid;
 		grid-template-columns: repeat(2, minmax(0, 1fr));
+		column-gap: 0.5rem;
 	}
+
 	.options-and-uppy {
 		display: grid;
 		grid-template-columns: minmax(20rem, 1fr) 2fr;

--- a/src/pages/examples.module.css
+++ b/src/pages/examples.module.css
@@ -99,7 +99,7 @@
 
 	.options {
 		grid-template-columns: repeat(2, minmax(0, 1fr));
-		gap: 0.5rem;
+		gap: 0.75rem;
 		align-items: center;
 	}
 
@@ -110,11 +110,11 @@
 	.options-inner[wrapper-for='Remote sources'] {
 		display: grid;
 		grid-template-columns: repeat(2, minmax(0, 1fr));
-		column-gap: 0.5rem;
+		column-gap: 0.75rem;
 	}
 
 	.options-and-uppy {
 		display: grid;
-		grid-template-columns: minmax(20rem, 1fr) 2fr;
+		grid-template-columns: minmax(18rem, 1fr) 2fr;
 	}
 }

--- a/src/pages/examples.tsx
+++ b/src/pages/examples.tsx
@@ -184,7 +184,7 @@ const options = [
 		],
 	},
 	{
-		heading: 'Uppy',
+		heading: 'Miscellaneous',
 		options: [
 			{ label: 'Restrictions', type: 'restrictions' },
 			{ label: 'Golden Retriever', value: 'GoldenRetriever', type: 'plugins' },

--- a/src/pages/examples.tsx
+++ b/src/pages/examples.tsx
@@ -404,7 +404,9 @@ function Page() {
 						})}
 
 						<div className={styles['options-locale']}>
-							<h3 className={styles['h3']}>Locale</h3>
+							<Heading className={styles['h3']} as="h3">
+								Locale
+							</Heading>
 							<select
 								name="locale"
 								onChange={(e) => {

--- a/src/pages/examples.tsx
+++ b/src/pages/examples.tsx
@@ -104,14 +104,14 @@ const options = [
 	{
 		heading: 'Remote sources',
 		options: [
-			{
-				label: 'Google Drive',
-				value: 'GoogleDrive',
-				type: 'plugins',
-				title:
-					'Temporarily disabled until our credentials are approved again. You can still use the plugin yourself.',
-				disabled: true,
-			},
+			// {
+			// 	label: 'Google Drive',
+			// 	value: 'GoogleDrive',
+			// 	type: 'plugins',
+			// 	title:
+			// 		'Temporarily disabled until our credentials are approved again. You can still use the plugin yourself.',
+			// 	disabled: true,
+			// },
 			{
 				label: 'Google Drive Picker',
 				value: 'GoogleDrivePicker',

--- a/src/pages/examples.tsx
+++ b/src/pages/examples.tsx
@@ -428,7 +428,7 @@ function Page() {
 					</div>
 				</section>
 				<Admonition type="note">
-					Checkout our{' '}
+					Check out our{' '}
 					<Link
 						href="https://github.com/transloadit/uppy/tree/main/examples"
 						target="_blank"

--- a/src/pages/examples.tsx
+++ b/src/pages/examples.tsx
@@ -403,23 +403,26 @@ function Page() {
 							);
 						})}
 
-						<select
-							name="locale"
-							onChange={(e) => {
-								setLocale(
-									locales.find((locale) => locale.name === e.target.value)
-										.locale,
-								);
-							}}
-						>
-							{locales.map(({ name }) => {
-								return (
-									<option key={name} value={name}>
-										{name}
-									</option>
-								);
-							})}
-						</select>
+						<div className={styles['options-locale']}>
+							<h3 className={styles['h3']}>Locale</h3>
+							<select
+								name="locale"
+								onChange={(e) => {
+									setLocale(
+										locales.find((locale) => locale.name === e.target.value)
+											.locale,
+									);
+								}}
+							>
+								{locales.map(({ name }) => {
+									return (
+										<option key={name} value={name}>
+											{name}
+										</option>
+									);
+								})}
+							</select>
+						</div>
 					</div>
 					<div className={styles['dashboard-inner']}>
 						<BrowserOnly>


### PR DESCRIPTION
Some design adjustments to the Examples page:
- Fixed label alignment when text wraps to a new line
- Renamed the "Uppy" subtitle to "Miscellaneous"
- Added a "Locale" subtitle above the locale `<select>`
- Improved the overall look and feel of the sidebar
- Fixed a typo

**Before:**
> ![Screenshot 2025-05-20 at 12 25 00@2x](https://github.com/user-attachments/assets/25035dc5-cb26-4f8f-87b3-7730e2effeec)

**After:**
> ![Screenshot 2025-05-20 at 12 25 14@2x](https://github.com/user-attachments/assets/79a63732-2dac-4f4c-bce3-f8750afea46b)
