### PR TITLE
Disambiguate bind the hook fn example in building-plugins.md

### DIFF
--- a/docs/guides/building-plugins.md
+++ b/docs/guides/building-plugins.md
@@ -186,8 +186,7 @@ class MyPlugin extends UIPlugin {
 		this.type = 'example';
 	}
 
-	prepareUpload = (fileIDs) => {
-		// ← this!
+	prepareUpload = (fileIDs) => { // ← this!
 		console.log(this); // `this` refers to the `MyPlugin` instance.
 		return Promise.resolve();
 	};


### PR DESCRIPTION
Minor docs page update to disambiguate "bind the hook fn" define the method as a class field example in building-plugins.md by moving `// ← this!` comment to same line as method.