### PR TITLE
Fix documentation for google drive

### DIFF
--- a/docs/sources/companion-plugins/google-drive.mdx
+++ b/docs/sources/companion-plugins/google-drive.mdx
@@ -103,10 +103,8 @@ uppy.use(GoogleDrive, {
 });
 ```
 
-You may also hit rate limits, because the OAuth application is shared between
-everyone using Transloadit.
-
-To solve that, you can use your own OAuth keys with Transloadit’s hosted
+Transloadit's OAuth2 key [no longer works](https://transloadit.com/blog/2025/02/the-new-google-situation/).
+This means that you have to use your own OAuth keys with Transloadit’s hosted
 Companion servers by using Transloadit Template Credentials. [Create a Template
 Credential][template-credentials] on the Transloadit site. Select “Companion
 OAuth” for the service, and enter the key and secret for the provider you want
@@ -125,6 +123,13 @@ uppy.use(GoogleDrive, {
 	},
 });
 ```
+
+Note that even if you use your own credentials, Google's OAuth2 Consent dialog
+will still show "transloadit.com" to your users, e.g.
+"transloadit.com wants to access your Google account".
+This is not the case with the Google Drive Picker plugin - it will show whatever
+you have specified in the "App name" form field at the Google developer console
+(https://console.cloud.google.com/auth/branding).
 
 ### Use in Companion
 

--- a/docs/sources/companion-plugins/google-drive.mdx
+++ b/docs/sources/companion-plugins/google-drive.mdx
@@ -126,10 +126,9 @@ uppy.use(GoogleDrive, {
 
 Note that even if you use your own credentials, Google's OAuth2 Consent dialog
 will still show "transloadit.com" to your users, e.g.
-"transloadit.com wants to access your Google account".
-This is not the case with the Google Drive Picker plugin - it will show whatever
-you have specified in the "App name" form field at the Google developer console
-(https://console.cloud.google.com/auth/branding).
+"transloadit.com wants to access your Google account" until your app has been
+verified, after which it should show what's in your "App name" form field in
+the [Google developer console](https://console.cloud.google.com/auth/branding).
 
 ### Use in Companion
 

--- a/docs/sources/companion-plugins/google-drive.mdx
+++ b/docs/sources/companion-plugins/google-drive.mdx
@@ -103,7 +103,8 @@ uppy.use(GoogleDrive, {
 });
 ```
 
-Transloadit's OAuth2 key [no longer works](https://transloadit.com/blog/2025/02/the-new-google-situation/).
+Transloadit’s OAuth2 key
+[no longer works](https://transloadit.com/blog/2025/02/the-new-google-situation/).
 This means that you have to use your own OAuth keys with Transloadit’s hosted
 Companion servers by using Transloadit Template Credentials. [Create a Template
 Credential][template-credentials] on the Transloadit site. Select “Companion
@@ -124,11 +125,11 @@ uppy.use(GoogleDrive, {
 });
 ```
 
-Note that even if you use your own credentials, Google's OAuth2 Consent dialog
-will still show "transloadit.com" to your users, e.g.
-"transloadit.com wants to access your Google account" until your app has been
-verified, after which it should show what's in your "App name" form field in
-the [Google developer console](https://console.cloud.google.com/auth/branding).
+Note that even if you use your own credentials, Google’s OAuth2 Consent dialog
+will still show “transloadit.com” to your users, e.g. “transloadit.com wants to
+access your Google account” until your app has been verified, after which it
+should show what’s in your “App name” form field in the
+[Google developer console](https://console.cloud.google.com/auth/branding).
 
 ### Use in Companion
 


### PR DESCRIPTION
Actually this might be because the app is not verified. Maybe Once the app is verified, Google will show the correct name