### PR TITLE
Fix broken example

### DIFF
--- a/docs/golden-retriever.mdx
+++ b/docs/golden-retriever.mdx
@@ -117,7 +117,7 @@ store references to large files.
 
    if ('serviceWorker' in navigator) {
    	navigator.serviceWorker
-   		.register('/sw.js') // path to your bundled service worker with GoldenRetriever service worker
+   		.register('/sw.js', { type: 'module' }) // path to your bundled service worker which imports GoldenRetriever service worker
    		.then((registration) => {
    			console.log(
    				'ServiceWorker registration successful with scope: ',


### PR DESCRIPTION
Updated service worker registration to use module type. Else we get an error that we cannot use import from a cjs file