### PR TITLE
Update migration guide for css imports on v5

### DIFF
--- a/docs/guides/migration-guides.md
+++ b/docs/guides/migration-guides.md
@@ -167,7 +167,7 @@ uppy.use(Dashboard, {
 
 All packages now have export maps. This is a breaking change in two cases:
 
-1. The css imports have changed from `@uppy[package]/css/style.min.css` to
+1. The css imports have changed from `@uppy[package]/dist/css/style.min.css` to
    `@uppy[package]/css/style.min.css`
 2. You were importing something that was not exported from the root, for
    instance `@uppy/core/lib/foo.js`. You can now only import things we


### PR DESCRIPTION
Update migration guide according to v5 announcement: https://github.com/transloadit/uppy.io/blob/main/blog/2025-08-00-uppy-5.0.mdx#export-maps-for-all-packages