### PR TITLE
Update note on UppyContextProvider usage

### DIFF
--- a/docs/framework-integrations/react.mdx
+++ b/docs/framework-integrations/react.mdx
@@ -71,7 +71,8 @@ Play around with the React headless components in StackBlitz
 
 :::note
 
-All components must be placed within a `UppyContextProvider`.
+All components must be placed within a `UppyContextProvider`. You typically only
+need a single `UppyContextProvider` at the root of your component hierarchy.
 
 :::
 


### PR DESCRIPTION
Clarified usage of UppyContextProvider in React components.

because when using AI agent, it tried to place multiple context providers around the code.