### PR TITLE
uppy 6.0 release blog and aws-s3 rewrite blog

### DIFF
--- a/blog/2026-08-31-aws-s3-rewrite.md
+++ b/blog/2026-08-31-aws-s3-rewrite.md
@@ -1,0 +1,287 @@
+---
+title: 'Rewriting @uppy/aws-s3 from scratch'
+date: 2026-08-31T09:00
+authors: [prakash, mifi, remcohaszing]
+slug: 'aws-s3-rewrite'
+published: true
+toc_max_heading_level: 2
+---
+
+`@uppy/aws-s3` has been Uppy’s most-used uploader plugin, but also the one with
+the most bug reports. Over the years, it accumulated nearly 2,000 lines of
+tightly coupled code, 11 user-facing callback options, and 8 Companion
+endpoints. Every bug fix risked breaking something else and nobody wanted to
+touch it.
+
+So we rewrote it.
+
+The new plugin closes
+[**13 open issues**](https://github.com/transloadit/uppy/issues/6055) and
+replaces 11 overlapping callbacks (which conflated signing with S3 protocol
+details) with 3 mutually exclusive signing modes, plus a few orthogonal config
+options. Companion is now optional: you can talk directly to any S3-compatible
+service from the browser.
+
+<!--truncate-->
+
+## Why a rewrite?
+
+The old plugin was the product of years of incremental additions. What started
+as a multipart uploader grew to handle single-part PUT uploads, presigned POST
+uploads, client-side SigV4 signing, Companion-backed signing, and more. All of
+it lived in one class with shared state and interleaved code paths. The
+[tracking issue](https://github.com/transloadit/uppy/issues/6055) sums it up:
+the plugin had become completely unwieldy, accumulating the highest number of
+[reported problems](https://github.com/transloadit/uppy/issues?q=is%3Aissue%20state%3Aopen%20aws%20s3).
+
+The new architecture splits things into two layers:
+
+- **S3mini**: a standalone, browser-native S3 client that doesn’t depend on
+  Uppy’s plugin system (the only Uppy code it uses is the internal `fetcher`
+  helper for XHR with retries). It handles presigned URLs, SigV4 signing,
+  multipart orchestration, XML parsing, retries with exponential backoff,
+  offline detection, and credential caching. It uses the
+  [Web Crypto API](https://developer.mozilla.org/docs/Web/API/Web_Crypto_API)
+  and `XMLHttpRequest`. (`XMLHttpRequest` is used instead of `fetch`, because
+  the Fetch API does not expose upload progress events; XHR’s
+  `xhr.upload.onprogress` is the only standard way to stream byte-count updates
+  into Uppy’s progress system.) No AWS SDK is needed.
+- **The plugin**: a thin wrapper that wires S3mini to Uppy’s file lifecycle
+  (progress events, pause/resume, abort, Golden Retriever state).
+
+Both sit on top of an `S3Client` abstract base, with `S3mini` and `CompanionS3`
+as the two concrete implementations. The orchestration code above doesn’t care
+which one is in use, so progress, retries, pause/resume, and resume-from-refresh
+all behave identically across signing modes.
+
+Each layer has one job. S3 protocol concerns stay in the client, Uppy concerns
+stay in the plugin.
+
+The S3mini client is forked from
+[good-lly/s3mini](https://github.com/good-lly/s3mini) (MIT-licensed, by Jølly
+Good), simplified and streamlined for browser use and integrated with Uppy’s
+upload lifecycle. Using a small, battle-tested S3 client as a starting point,
+instead of reinventing SigV4, was the single biggest reason this rewrite was
+tractable.
+
+## 3 signing modes
+
+The old plugin exposed 11 callback options and it was never clear which
+combination to provide. The new plugin replaces all of that with **3 mutually
+exclusive signing modes**:
+
+### `getCredentials` : client-side signing
+
+Your backend returns temporary STS credentials. The plugin signs all requests in
+the browser using SigV4. No server round-trip per request.
+
+```js
+new Uppy().use(AwsS3, {
+	s3Endpoint: 'https://my-bucket.s3.us-east-1.amazonaws.com',
+	getCredentials: async () => {
+		const res = await fetch('/api/s3/credentials');
+		return res.json();
+		// {
+		//   credentials: { accessKeyId, secretAccessKey, sessionToken },
+		//   region: 'us-east-1',
+		// }
+	},
+});
+```
+
+The `region` used for signing comes from the `getCredentials` response. You can
+also pass it as a plugin option. If neither is set, it falls back to `auto`.
+This is fine for region-less services like Cloudflare R2, but for AWS you need
+to supply the real region one way or the other.
+
+### `signRequest` : bring your own signer
+
+Your backend signs each request and returns a presigned URL. No other options
+needed; the upload location is derived from the presigned URL itself.
+
+```js
+new Uppy().use(AwsS3, {
+	signRequest: async ({ method, key, uploadId, partNumber }) => {
+		const res = await fetch('/api/s3/sign', {
+			method: 'POST',
+			body: JSON.stringify({ method, key, uploadId, partNumber }),
+		});
+		return res.json(); // { url: 'https://presigned-url.example' }
+	},
+});
+```
+
+### `companionEndpoint` : Companion signing
+
+Point the plugin at your Companion server. Nothing else to configure.
+
+```js
+new Uppy().use(AwsS3, {
+	companionEndpoint: 'https://companion.example',
+});
+```
+
+Options like `shouldUseMultipart`, `getChunkSize`, `limit`, `generateObjectKey`,
+and `allowedMetaFields` are still available as simple configurations. They
+simply no longer function as callbacks that replace S3 operations.
+
+## Companion is now optional
+
+The old plugin essentially required a Companion server (or a custom callback for
+every S3 operation) to do anything. The new plugin lets you talk directly to any
+S3-compatible service from the browser using `signRequest` or `getCredentials`.
+Companion is removed entirely from the data path.
+
+Existing Companion deployments still work unchanged. The `companionEndpoint`
+mode reuses the same Companion endpoints the old plugin used, so server-side key
+generation (`config.getKey()`), STS credential issuance, and presigning all keep
+behaving the same. The only migration step on the client is renaming `endpoint`
+→ `companionEndpoint`.
+
+## Use any S3-compatible service
+
+The new `s3Endpoint` option accepts any S3-compatible endpoint URL. That
+includes Cloudflare R2, MinIO, DigitalOcean Spaces, Backblaze B2, or anything
+else that speaks the S3 protocol:
+
+```js
+// Cloudflare R2
+new Uppy().use(AwsS3, {
+	s3Endpoint: 'https://<account-id>.r2.cloudflarestorage.com/my-bucket',
+	getCredentials: () => fetchR2Credentials(),
+});
+
+// AWS S3 with Transfer Acceleration
+new Uppy().use(AwsS3, {
+	s3Endpoint: 'https://my-bucket.s3-accelerate.amazonaws.com',
+	getCredentials: () => fetchCredentials(),
+});
+```
+
+## Reliability improvements
+
+Many of the old bugs came down to how Uppy events were wired around S3 ops. The
+rewrite addresses these:
+
+- Automatic retry with exponential backoff on 5xx and 429 errors.
+- On `ExpiredToken`, the plugin clears its credential cache and retries with
+  fresh credentials. No user intervention needed.
+- Offline detection via `navigator.onLine`. Between requests, the client waits
+  for the connection to come back before firing the next request, instead of
+  failing the upload.
+- Each file gets its own `S3Uploader` instance, so one stalled upload can’t
+  corrupt another’s state.
+- `allowedMetaFields` is now respected on remote uploads (Companion-backed
+  provider files). The old plugin sent the full `file.meta` regardless, which
+  could leak unwanted internal fields and risked hitting S3’s 2KB metadata
+  limit.
+
+To catch the kind of bugs unit tests miss (wrong query-parameter ordering,
+broken canonical request strings, content-type mismatches), we run the S3 client
+against a real S3-compatible server. A MinIO container is started in Docker by
+Vitest setup hooks, every multipart operation runs end-to-end against it, and
+the container is torn down after the suite. The same infrastructure means
+contributors can reproduce signing bugs locally without hitting AWS.
+
+## Migration guide
+
+### From `endpoint` (Companion) mode
+
+```js
+// Before
+new Uppy().use(AwsS3, {
+	endpoint: 'https://companion.example',
+});
+
+// After
+new Uppy().use(AwsS3, {
+	companionEndpoint: 'https://companion.example',
+});
+```
+
+### From `getTemporarySecurityCredentials`
+
+```js
+// Before
+new Uppy().use(AwsS3, {
+	endpoint: 'https://companion.example',
+	getTemporarySecurityCredentials: true,
+});
+
+// After
+new Uppy().use(AwsS3, {
+	s3Endpoint: 'https://my-bucket.s3.us-east-1.amazonaws.com',
+	region: 'us-east-1',
+	getCredentials: async () => {
+		const res = await fetch('/api/s3/sts');
+		return res.json();
+	},
+});
+```
+
+### From custom callbacks
+
+The old plugin had 6 separate callbacks, one per S3 operation, meaning your
+backend had to expose and handle each operation individually. The new plugin
+replaces all of them with a single `signRequest` and every operation is done
+from the client side. The backend now only returns the presigned URL for that
+operation.
+
+```js
+// Before: 6 separate callbacks
+new Uppy().use(AwsS3, {
+	getUploadParameters: (file) => {
+		/* ... */
+	},
+	createMultipartUpload: (file) => {
+		/* ... */
+	},
+	signPart: (file, partData) => {
+		/* ... */
+	},
+	completeMultipartUpload: (file, data) => {
+		/* ... */
+	},
+	abortMultipartUpload: (file, data) => {
+		/* ... */
+	},
+	listParts: (file, data) => {
+		/* ... */
+	},
+});
+
+// After: one callback that switches on the operation
+new Uppy().use(AwsS3, {
+	signRequest: async ({ method, key, uploadId, partNumber }) => {
+		const res = await fetch('/api/s3/sign', {
+			method: 'POST',
+			body: JSON.stringify({ method, key, uploadId, partNumber }),
+		});
+		return res.json(); // { url }
+	},
+});
+```
+
+Your `/api/s3/sign` endpoint receives `{ method, key, uploadId, partNumber }`
+and returns a presigned URL for that operation. This consolidation means one
+server route instead of six, with consistent flow and logging in one place. The
+plugin owns the upload flow and backend is only used for signing.
+
+### Breaking changes
+
+- **Removed:** `getUploadParameters`, `createMultipartUpload`, `signPart`,
+  `listParts`, `completeMultipartUpload`, `abortMultipartUpload`,
+  `getTemporarySecurityCredentials`, `uploadPartBytes`, `retryDelays`,
+  `headers`, `cookiesRule`. There is currently no replacement for
+  `headers`/`cookiesRule` if you used them for authenticated Companion setups.
+  The bucket is now part of the `s3Endpoint` URL, e.g.,
+  `https://my-bucket.s3.us-east-1.amazonaws.com`.
+- **Renamed:** `endpoint` to `companionEndpoint`.
+- **New:** `s3Endpoint` (required for `getCredentials` mode) and `region`
+  (optional: comes from the `getCredentials` response or the option itself, and
+  falls back to `auto`, which only works for region-less services like R2).
+- **Required:** one of `getCredentials`, `signRequest`, or `companionEndpoint`.
+- **Simplified:** `signRequest` and `companionEndpoint` modes need no other
+  options. The upload location is derived from the presigned URL.
+- **Companion:** server-side unchanged. Existing `/s3/*` endpoints continue to
+  work. Only the client option name changed (`endpoint` → `companionEndpoint`).

--- a/blog/2026-08-31-uppy-6.0.md
+++ b/blog/2026-08-31-uppy-6.0.md
@@ -1,0 +1,202 @@
+---
+title: 'Uppy 6.0 : fewer packages, fewer moving parts, and a robust S3 Plugin'
+date: 2026-08-31T12:00
+authors: [prakash, mifi, remcohaszing]
+slug: 'uppy-6.0'
+published: true
+toc_max_heading_level: 2
+---
+
+Uppy 6.0 is here, freshly groomed and ready to play. Rather than teaching it new
+tricks, we spent this release mostly cleaning up after our faithful
+file-uploading companion. Every pup needs a bath eventually.
+
+We rewrote `@uppy/aws-s3` from scratch, folded four packages into `@uppy/core`,
+and dropped a fifth entirely.
+
+If you have ever debugged a duplicate-version bug in your lockfile or given up
+halfway through configuring an S3 upload, this release is for you.
+
+<!--truncate-->
+
+## Migration guide
+
+This post covers the highlights. Six packages take a major bump: `@uppy/core`,
+`@uppy/companion`, `@uppy/aws-s3`, `@uppy/tus`, `@uppy/components`, and `uppy`.
+
+**If you use the `uppy` meta-package or the CDN bundle, most of this release
+requires no changes on your side.**
+
+We have an accompanying [migration guide](/docs/guides/migration-guides/) for
+everyone else.
+
+## `@uppy/aws-s3`, rewritten from scratch
+
+Configuring the old plugin meant implementing up to eight callbacks:
+`getUploadParameters`, `getTemporarySecurityCredentials`, `uploadPartBytes`,
+`signPart`, `createMultipartUpload`, `listParts`, `abortMultipartUpload`, and
+`completeMultipartUpload`. Which ones you needed depended on whether you were
+doing multipart, whether Companion was in the picture, and whether you were
+signing on the client. Nothing told you that up front. You read all eight and
+guessed.
+
+We received many reports from people who had wired up a plausible-looking
+combination that quietly did not work. Over time, it became clear that the
+problem was the shape of the API rather than any individual bug in it. So we
+started over.
+
+There are now three signing modes, and you pick exactly one:
+
+```js
+import Uppy from '@uppy/core';
+import AwsS3 from '@uppy/aws-s3';
+
+new Uppy().use(AwsS3, {
+	s3Endpoint: 'https://my-bucket.s3.eu-west-1.amazonaws.com',
+	region: 'eu-west-1',
+	getCredentials: async () => fetch('/s3-credentials').then((r) => r.json()),
+});
+```
+
+The example above uses `getCredentials`, which signs on the client using SigV4.
+The other two are `signRequest`, where you bring your own signer, and
+`companionEndpoint`, where Companion signs for you.
+
+**Companion is no longer required in the data path, and neither is AWS.**
+
+The plugin now talks to any S3-compatible service, so Cloudflare R2, MinIO and
+DigitalOcean Spaces work, without the need for any provider-specific code.
+
+The rewrite also closed a significant number of reliability bugs that had been
+open for a while: retries with backoff, credential expiry, offline detection,
+and pause/resume races during multipart uploads. The plugin is now tested
+against a real MinIO instance in CI instead of mocks, which is how several of
+those bugs were caught in the first place.
+
+**[Read the full rewrite deep-dive →](/blog/aws-s3-rewrite)**
+
+## One core: a single source of truth
+
+We published `@uppy/utils`, `@uppy/store-default`, `@uppy/companion-client` and
+`@uppy/provider-views` as separate packages, because that is what a monorepo
+invites you to do. They are no longer published separately. Their code ships
+inside `@uppy/core` as subpath exports:
+
+```diff
+- import { fetcher } from '@uppy/utils'
++ import { fetcher } from '@uppy/core/utils'
+
+- import { RequestClient } from '@uppy/companion-client'
++ import { RequestClient } from '@uppy/core/companion-client'
+```
+
+This was not housekeeping. Those four packages sat behind every plugin as
+sub-dependencies, which meant a lockfile could, and regularly did, pin an old
+copy of one of them while `@uppy/core` moved on. While users simply saw “Uppy is
+broken”, in actuality there were two versions of `@uppy/utils` in the same tree.
+
+Every plugin already depends on `@uppy/core`, so there is now only one source of
+truth. And as a result, that entire category of bugs is gone.
+
+Removing the package boundary bought us something else as well: co-dependent
+types can finally reference each other directly. `CompanionClientProvider` and
+`CompanionClientSearchProvider` were hand-maintained stand-ins that only existed
+because `@uppy/utils` could not see the real provider classes. Keeping them in
+sync was a chore nobody enjoyed. Both are removed. Import `Provider` from
+`@uppy/core/companion-client` instead.
+
+## Transloadit: build your own assembly UI
+
+`@uppy/transloadit` now puts assembly status in plugin state, so you can build
+your own progress UI instead of styling ours:
+
+```jsx
+import { useUppyState } from '@uppy/react';
+
+function AssemblyProgress({ uppy }) {
+	const { assemblyStatus, lastAssemblyStatus } = useUppyState(
+		uppy,
+		(state) => state.plugins.Transloadit,
+	);
+
+	const status = assemblyStatus ?? lastAssemblyStatus;
+	if (!status) return null;
+
+	return <p>{status.ok}</p>;
+}
+```
+
+`assemblyStatus` follows the live assembly through every transition and clears
+when there is no active assembly. `lastAssemblyStatus` keeps the previous run’s
+result around, so your UI has something to show between uploads instead of
+flickering to empty. That second field exists because the first one on its own
+made for a UI that kept blanking out, which we only noticed once we tried
+building something with it.
+
+Recovery got better alongside it. `@uppy/golden-retriever` now stores file
+metadata in IndexedDB and falls back to localStorage where IndexedDB is not
+available. The old localStorage-only store ran into quota limits on large
+assemblies, so the uploads most worth recovering were the ones that could not be
+recovered. Large assemblies now restore.
+
+## Companion
+
+### OAuth tokens now travel over a WebSocket
+
+Companion used to hand the token back through `window.opener`. It now sends it
+over the WebSocket connection instead. **This breaks in both directions:
+`@uppy/core` needs the newest Companion, and `companion.socket()` now takes
+`companionOptions` as its second argument.** If you self-host, upgrade both
+sides together. If you use hosted Companion, you do not need to do anything.
+
+### Express 5
+
+Companion runs on Express 5. If you mount it as middleware inside an Express 4
+app, it will no longer work. You will need to upgrade your app first.
+
+### TypeScript
+
+Companion is written in TypeScript as of this release. On paper, that changes
+nothing for you. Ports of this size tend to shake things loose, though, so
+please report anything that looks off.
+
+## Supply-chain hardening
+
+After a rough year for the npm ecosystem, we tightened up how dependencies enter
+this repository. Packages must be at least seven days old before Yarn will
+resolve them. Dependabot updates carry a matching cooldown, and every
+third-party GitHub Action is pinned to a commit SHA. Security updates
+deliberately bypass the cooldown, so fixes still land immediately.
+
+None of this changes the API you write against. It changes what can end up in a
+release, which felt worth the trouble.
+
+## Deprecations and removals
+
+- `@uppy/instagram` is removed. In 2024 Instagram disabled their API and the
+  plugin stopped working, so we have now finally removed it.
+- `@uppy/utils`, `@uppy/store-default`, `@uppy/companion-client` and
+  `@uppy/provider-views` are no longer published as standalone packages. Their
+  existing releases stay on npm but are deprecated. See
+  [One core](#one-core-a-single-source-of-truth).
+- Provider CSS moved to `@uppy/core/provider-views/css/style.min.css`. Most apps
+  never imported this directly, since it ships bundled in `@uppy/dashboard`’s
+  CSS.
+
+## And more
+
+`@uppy/tus` no longer aborts the request when it errors, so the server’s status
+and body now reach `upload-error` and `file.response` instead of arriving as
+status `0`. If you have error-handling code written against the old behavior,
+give it a look.
+
+Beyond that: Angular 22 support in `@uppy/angular`, the Dashboard’s “My Device”
+button now respects `fileManagerSelectionType`, and locale updates including
+Norwegian Bokmål.
+
+This release contains 58 pull requests. Most of them are too small to mention
+here, but they all add up to a version we are happy to put our name on.
+
+Ready to upgrade? Start with the
+[migration guide](/docs/guides/migration-guides/), and
+[open an issue](https://github.com/transloadit/uppy/issues) if something breaks.

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -85,3 +85,8 @@ prakash:
   id: 'prakash'
   tagline: 'Developer'
   image_url: 'https://github.com/qxprakash.png'
+remcohaszing:
+  name: 'Remco Haszing'
+  id: 'remco'
+  tagline: 'Developer'
+  image_url: 'https://github.com/remcohaszing.png'

--- a/docs/guides/migration-guides.md
+++ b/docs/guides/migration-guides.md
@@ -334,11 +334,13 @@ needed, but recovery snapshots written by 5.x (in localStorage) are not read by
   match.
 - Backwards compat token decryption removed: old Uppy auth tokens (created
   before
-  [uppy%404.16.0](https://github.com/transloadit/uppy/releases/tag/uppy%404.16.0)
-  06d9a7c689e5123d41b38191074eb8bbd4ff5325) will become invalid and users who
-  have these old toknes will have to re-authenticate.
+  [`uppy@4.16.0`](https://github.com/transloadit/uppy/releases/tag/uppy%404.16.0),
+  commit
+  [`06d9a7c`](https://github.com/transloadit/uppy/commit/06d9a7c689e5123d41b38191074eb8bbd4ff5325))
+  will become invalid, and users who have these old tokens will have to
+  re-authenticate.
 - Removed `token` param from `Provider` class methods: `list()`, `download()`,
-  `logout()`, `thumbnail()`. Please use: `providerUserSession`.`accessToken`
+  `logout()`, `thumbnail()`. Please use `providerUserSession.accessToken`
   instead.
 
 ## Migrate from Uppy 4.x to 5.x


### PR DESCRIPTION
still WIP , latest API changes taken from https://github.com/transloadit/uppy/pull/6186 which has not been merged yet to the `uppy-aws-s3-rewrite` base branch 