### PR TITLE
Replace workflow helper actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,14 +12,24 @@ env:
   NODE_VERSION: lts/*
 
 permissions:
-  contents: write
+  contents: read
+  id-token: write
+  pages: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
 
 jobs:
   deploy:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/configure-pages@v6
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -32,11 +42,11 @@ jobs:
       - name: Build website
         run: corepack yarn build
 
-      # Recommended action by Docusaurus:
-      # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v5
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Build output to publish to the `gh-pages` branch:
-          publish_dir: ./build
+          path: ./build
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -45,19 +45,52 @@ jobs:
         with:
           persist-credentials: false
       - run: ${{ matrix.run }}
-      - uses: gr2m/create-or-update-pull-request-action@v1
-        # Creates a PR or update the Action's existing PR, or
-        # no-op if the base branch is already up-to-date.
+      - name: Create or update pull request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          body:
-            This is an automated update of ${{ matrix.id }} to ${{
-            env.NEW_VERSION }}.
-          branch: actions/tools-update-${{ matrix.id }} # Custom branch *just* for this Action.
-          commit-message:
-            '${{ matrix.subsystem }}: update ${{ matrix.id }} to ${{
-            env.NEW_VERSION }}'
-          title:
-            '${{ matrix.subsystem }}: update ${{ matrix.id }} to ${{
-            env.NEW_VERSION }}'
+          BRANCH_NAME: actions/tools-update-${{ matrix.id }}
+          COMMIT_MESSAGE: '${{ matrix.subsystem }}: update ${{ matrix.id }} to ${{ env.NEW_VERSION }}'
+          PR_BODY: This is an automated update of ${{ matrix.id }} to ${{ env.NEW_VERSION }}.
+          PR_TITLE: '${{ matrix.subsystem }}: update ${{ matrix.id }} to ${{ env.NEW_VERSION }}'
+        run: |
+          set -euo pipefail
+
+          if git diff --cached --quiet; then
+            echo "No dependency changes to publish."
+            exit 0
+          fi
+
+          base_sha="${{ github.sha }}"
+          if ! gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BRANCH_NAME}" >/dev/null 2>&1; then
+            gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/heads/${BRANCH_NAME}" \
+              -f sha="${base_sha}" >/dev/null
+          fi
+
+          file_sha="$(gh api "repos/${GITHUB_REPOSITORY}/contents/yarn.lock?ref=${BRANCH_NAME}" --jq .sha)"
+          local_sha="$(git hash-object yarn.lock)"
+          if [ "${local_sha}" = "${file_sha}" ]; then
+            echo "${BRANCH_NAME} already has the generated yarn.lock."
+          else
+            content="$(base64 -w 0 yarn.lock)"
+            gh api \
+              --method PUT \
+              "repos/${GITHUB_REPOSITORY}/contents/yarn.lock" \
+              -f branch="${BRANCH_NAME}" \
+              -f message="${COMMIT_MESSAGE}" \
+              -f content="${content}" \
+              -f sha="${file_sha}" >/dev/null
+          fi
+
+          if gh pr view "${BRANCH_NAME}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "Updated existing pull request for ${BRANCH_NAME}."
+          else
+            gh pr create \
+              --repo "${GITHUB_REPOSITORY}" \
+              --base main \
+              --head "${BRANCH_NAME}" \
+              --title "${PR_TITLE}" \
+              --body "${PR_BODY}"
+          fi


### PR DESCRIPTION
Why

Reduce GitHub Actions supply-chain exposure by replacing two workflow helper actions with GitHub-owned Pages actions and direct GitHub API calls.

What changed

- Replaces `peaceiris/actions-gh-pages` with `actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages`.
- Replaces `gr2m/create-or-update-pull-request-action` with `gh`/GitHub Contents API logic that updates `yarn.lock` on the automation branch and opens a PR if needed.

Operational note

GitHub Pages must be configured for GitHub Actions deployments before the deploy workflow can replace branch-based Pages publishing.

Validation

- Ruby YAML parse for changed workflows
- `git diff --check`