### PR TITLE
Describe Uppy with structured data

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,6 +4,57 @@
 const { themes } = require('prism-react-renderer');
 const lightCodeTheme = themes.github;
 
+const uppyStructuredData = {
+	'@context': 'https://schema.org',
+	'@graph': [
+		{
+			'@id': 'https://uppy.io/#software',
+			'@type': 'SoftwareApplication',
+			applicationCategory: 'DeveloperApplication',
+			applicationSubCategory: 'File uploader',
+			creator: { '@id': 'https://transloadit.com/#organization' },
+			description:
+				'Uppy is an open-source, modular JavaScript file uploader created and maintained by Transloadit.',
+			downloadUrl: 'https://www.npmjs.com/package/@uppy/core',
+			isAccessibleForFree: true,
+			license: 'https://opensource.org/license/mit/',
+			name: 'Uppy',
+			offers: {
+				'@type': 'Offer',
+				price: '0',
+				priceCurrency: 'USD',
+			},
+			operatingSystem: 'Any',
+			publisher: { '@id': 'https://transloadit.com/#organization' },
+			sameAs: [
+				'https://github.com/transloadit/uppy',
+				'https://www.npmjs.com/package/@uppy/core',
+			],
+			url: 'https://uppy.io/',
+		},
+		{
+			'@id': 'https://uppy.io/#source',
+			'@type': 'SoftwareSourceCode',
+			codeRepository: 'https://github.com/transloadit/uppy',
+			creator: { '@id': 'https://transloadit.com/#organization' },
+			description:
+				'The MIT-licensed source code for Uppy, a backend-independent web file uploader.',
+			license: 'https://opensource.org/license/mit/',
+			name: 'Uppy',
+			programmingLanguage: ['TypeScript', 'JavaScript'],
+			runtimePlatform: 'Web browser',
+			url: 'https://uppy.io/',
+		},
+		{
+			'@id': 'https://transloadit.com/#organization',
+			'@type': 'Organization',
+			name: 'Transloadit',
+			sameAs: ['https://github.com/transloadit'],
+			url: 'https://transloadit.com/',
+		},
+	],
+};
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
 	title: 'Uppy',
@@ -22,6 +73,13 @@ const config = {
 		},
 	},
 	headTags: [
+		{
+			tagName: 'script',
+			attributes: {
+				type: 'application/ld+json',
+			},
+			innerHTML: JSON.stringify(uppyStructuredData),
+		},
 		{
 			tagName: 'meta',
 			attributes: {


### PR DESCRIPTION
## Summary

- identify Uppy as a schema.org `SoftwareApplication` and `SoftwareSourceCode` entity
- identify Transloadit as Uppy’s creator and publisher through a linked `Organization` entity
- publish canonical repository, npm package, MIT license, language, runtime, and project URLs
- emit the same stable entity graph throughout Uppy.io

## Validation

- `yarn prettier -c docusaurus.config.js`
- `yarn build`
- parsed the emitted JSON-LD from both `/` and `/docs/quick-start/`
- confirmed both pages contain `SoftwareApplication`, `SoftwareSourceCode`, and `Organization`

The repository’s existing `yarn typecheck` currently fails in `FilesGrid.tsx`, `FilesList.tsx`, and existing `JSX` namespace annotations; this branch does not touch those files. The production Docusaurus build succeeds.
