### PR TITLE
Fix Prettier formatting in update-deps.yml and README.md

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -46,6 +46,9 @@ jobs:
           persist-credentials: false
       - run: ${{ matrix.run }}
       - name: Create or update pull request
+        # pull_request runs only validate the workflow; their GITHUB_TOKEN is
+        # read-only, so publishing the update must be skipped.
+        if: github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: actions/tools-update-${{ matrix.id }}

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -49,9 +49,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: actions/tools-update-${{ matrix.id }}
-          COMMIT_MESSAGE: '${{ matrix.subsystem }}: update ${{ matrix.id }} to ${{ env.NEW_VERSION }}'
-          PR_BODY: This is an automated update of ${{ matrix.id }} to ${{ env.NEW_VERSION }}.
-          PR_TITLE: '${{ matrix.subsystem }}: update ${{ matrix.id }} to ${{ env.NEW_VERSION }}'
+          COMMIT_MESSAGE:
+            '${{ matrix.subsystem }}: update ${{ matrix.id }} to ${{
+            env.NEW_VERSION }}'
+          PR_BODY:
+            This is an automated update of ${{ matrix.id }} to ${{
+            env.NEW_VERSION }}.
+          PR_TITLE:
+            '${{ matrix.subsystem }}: update ${{ matrix.id }} to ${{
+            env.NEW_VERSION }}'
         run: |
           set -euo pipefail
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Code for [uppy.io/docs](https://uppy.io/docs/quick-start) lives in
 
 ## Developer guide
 
-If you want to edit [uppy.io/blog](https://uppy.io/blog), edit the files in
-this repo.
+If you want to edit [uppy.io/blog](https://uppy.io/blog), edit the files in this
+repo.
 
 If you want to edit [uppy.io/docs](https://uppy.io/docs/quick-start), then you
 should:


### PR DESCRIPTION
also:

Skip publish step of update-deps on pull_request runs:

PR-triggered runs exist only to validate changes to the workflow file; their GITHUB_TOKEN is read-only, so the gh api write calls fail with 403. This made the PR fail here in a fork: https://github.com/mifi/uppy.io/pull/1

resoning behind this additional change:

https://claude.ai/code/session_01NjT5Zmbo6nzZsirLZnJK2q