### PR TITLE
@uppy/aws-s3: update docs for signRequest signing mode

### DIFF
--- a/blog/2026-08-31-aws-s3-rewrite.md
+++ b/blog/2026-08-31-aws-s3-rewrite.md
@@ -97,7 +97,9 @@ to supply the real region one way or the other.
 ### `signRequest` : bring your own signer
 
 Your backend signs each request and returns a presigned URL. No other options
-needed; the upload location is derived from the presigned URL itself.
+needed; the presigned URL determines where the bytes go. If your backend chooses
+a different key, it returns it as `key`, and Uppy uses that key for the rest of
+the upload.
 
 ```js
 new Uppy().use(AwsS3, {
@@ -106,7 +108,7 @@ new Uppy().use(AwsS3, {
 			method: 'POST',
 			body: JSON.stringify({ method, key, uploadId, partNumber }),
 		});
-		return res.json(); // { url: 'https://presigned-url.example' }
+		return res.json(); // { url: 'https://presigned-url.example' }, key is optional
 	},
 });
 ```
@@ -257,7 +259,7 @@ new Uppy().use(AwsS3, {
 			method: 'POST',
 			body: JSON.stringify({ method, key, uploadId, partNumber }),
 		});
-		return res.json(); // { url }
+		return res.json(); // { url } or { url, key }
 	},
 });
 ```
@@ -266,6 +268,16 @@ Your `/api/s3/sign` endpoint receives `{ method, key, uploadId, partNumber }`
 and returns a presigned URL for that operation. This consolidation means one
 server route instead of six, with consistent flow and logging in one place. The
 plugin owns the upload flow and backend is only used for signing.
+
+If your backend generates its own object keys, see the
+[`signRequest` docs](/docs/aws-s3/#signrequestrequest) and the
+[migration guide](/docs/guides/migration-guides/#custom-signing-six-callbacks-become-signrequest)
+for what changed from v5, why, and how to implement the signer correctly. See
+also the
+[Node.js](https://github.com/transloadit/uppy/blob/main/examples/aws-nodejs/routes/presign.js)
+and
+[PHP](https://github.com/transloadit/uppy/blob/main/examples/aws-php/s3-sign.php)
+signer examples.
 
 ### Breaking changes
 

--- a/docs/guides/migration-guides.md
+++ b/docs/guides/migration-guides.md
@@ -253,7 +253,7 @@ type PresignableRequest = {
 ```
 
 The object key is now generated on the client (via `generateObjectKey`, by
-default `${crypto.randomUUID()}-${file.name}`). In 5.x the server's key was
+default `${crypto.randomUUID()}-${file.name}`). In 5.x the server’s key was
 authoritative: `getUploadParameters` returned it in `fields.key`, and
 `createMultipartUpload` returned it directly. In 6.x, if your server stores the
 object under a different key, it must tell Uppy. Return that key as `key` next

--- a/docs/guides/migration-guides.md
+++ b/docs/guides/migration-guides.md
@@ -234,7 +234,7 @@ uppy.use(AwsS3, {
 			body: JSON.stringify(request),
 		});
 		if (!response.ok) throw new Error('Failed to sign request');
-		return response.json(); // { url }
+		return response.json(); // { url }, or { url, key } (see below)
 	},
 });
 ```
@@ -251,6 +251,28 @@ type PresignableRequest = {
 	expiresIn?: number;
 };
 ```
+
+The object key is now generated on the client (via `generateObjectKey`, by
+default `${crypto.randomUUID()}-${file.name}`). In 5.x the server's key was
+authoritative: `getUploadParameters` returned it in `fields.key`, and
+`createMultipartUpload` returned it directly. In 6.x, if your server stores the
+object under a different key, it must tell Uppy. Return that key as `key` next
+to `url` in the response to the request that creates the upload (available from
+`@uppy/aws-s3` 6.1.0). If the server uses the key Uppy sent, leave `key` out.
+Change the key only on that request: every later request carries an `uploadId`
+and must be signed for exactly the key it arrives with, which was fixed when the
+upload was created.
+
+If your server changes the key but does not return it, a single-part upload
+still succeeds, but `upload-success` reports a key that does not exist in the
+bucket. A multipart upload only works if your server turns the same input into
+the same key on every request, because Uppy keeps passing the key it generated
+to `signRequest`. A server that generates a unique key at create time fails at
+the first part with `NoSuchUpload`. The
+[Node.js](https://github.com/transloadit/uppy/blob/main/examples/aws-nodejs/routes/presign.js)
+and
+[PHP](https://github.com/transloadit/uppy/blob/main/examples/aws-php/s3-sign.php)
+signer examples show how to return the key correctly.
 
 This mode needs no `s3Endpoint`: the presigned URLs you return are absolute.
 

--- a/docs/uploader/aws-s3.mdx
+++ b/docs/uploader/aws-s3.mdx
@@ -120,7 +120,8 @@ new Uppy().use(Dashboard, { inline: true, target: 'body' }).use(AwsS3, {
 			body: JSON.stringify({ method, key, uploadId, partNumber }),
 		});
 		if (!response.ok) throw new Error('Failed to sign S3 request');
-		// The server responds with `{ "url": "https://…" }`
+		// The server responds with `{ "url": "https://…" }`,
+		// optionally with a `key` if it stored the object elsewhere
 		return response.json();
 	},
 });
@@ -277,6 +278,9 @@ uppy.use(AwsS3, {
 });
 ```
 
+The key generated here is a proposal. With [`signRequest`](#signrequestrequest),
+your server can store the object under a different key by returning it as `key`.
+
 Not used with [`companionEndpoint`](#companionendpoint): Companion generates the
 key.
 
@@ -293,8 +297,12 @@ It receives an object with:
 - `uploadId`: `string`, only present for multipart operations.
 - `partNumber`: `number`, only present when uploading a part.
 
-It must return a promise for an object with a single `url` key holding the
-presigned URL.
+It must return a promise for an object with:
+
+- `url`: `string`, the presigned URL.
+- `key`: `string`, optional. The key your server stored the object under. Uppy
+  uses it for the rest of the upload and reports it in `upload-success`. Leave
+  it out if the server used the key Uppy sent.
 
 These are the operations your endpoint has to sign:
 
@@ -309,6 +317,18 @@ These are the operations your endpoint has to sign:
 
 If [`shouldUseMultipart`](#shouldusemultipartfile) is `false` for every file,
 the first row is the only one you need.
+
+To generate the object key on your server instead, change it only on the request
+that creates the object: the single-part `PUT`, or the `POST` without an
+`uploadId`. Return the key you used as `key` there. Every request that carries
+an `uploadId` must be signed for exactly the key it arrives with. That key was
+fixed when the upload was created, and a `key` returned on those requests is
+ignored. A server that derives the key again on every request prefixes a key
+that is already prefixed, and S3 answers with `NoSuchUpload`. The
+[Node.js](https://github.com/transloadit/uppy/blob/main/examples/aws-nodejs/routes/presign.js)
+and
+[PHP](https://github.com/transloadit/uppy/blob/main/examples/aws-php/s3-sign.php)
+signer examples show how to do this correctly.
 
 #### `getCredentials()`
 


### PR DESCRIPTION
this should be merged after the next minor uppy release : https://github.com/transloadit/uppy/pull/6511

from https://github.com/transloadit/uppy/pull/6498
more context : https://transloadit.slack.com/archives/C0FMW9PSB/p1788213489397289